### PR TITLE
Refactor type hints to use built-in types and improve code consistency

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,6 @@ import os
 from pathlib import Path
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional
 
 
 # === Container Detection ===
@@ -116,7 +115,7 @@ class Settings:
     # Paths
     VIDEOS_FOLDER: Path
     TMP_DOWNLOAD_FOLDER: Path
-    YOUTUBE_COOKIES_FILE_PATH: Optional[str]
+    YOUTUBE_COOKIES_FILE_PATH: str | None
     COOKIES_FROM_BROWSER: str
 
     # Localization

--- a/app/constants.py
+++ b/app/constants.py
@@ -6,12 +6,11 @@ Importing from here ensures consistency and eliminates duplication.
 """
 
 import re
-from typing import List, Pattern, Set
 
 # === AUTHENTICATION ERROR PATTERNS ===
 # Used to detect authentication-related errors in yt-dlp output.
 # Shared between main.py and logs_utils.py
-AUTH_ERROR_PATTERNS: List[str] = [
+AUTH_ERROR_PATTERNS: list[str] = [
     "sign in to confirm",
     "please log in",
     "login required",
@@ -29,12 +28,14 @@ AUTH_ERROR_PATTERNS: List[str] = [
 # === ANSI ESCAPE PATTERN ===
 # Regular expression to strip ANSI color codes and control sequences from logs.
 # Used in main.py and logs_utils.py for log cleaning.
-ANSI_ESCAPE_PATTERN: Pattern = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+ANSI_ESCAPE_PATTERN: re.Pattern[str] = re.compile(
+    r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])"
+)
 
 # === BROWSER SUPPORT ===
 # Valid browsers for cookie extraction (yt-dlp --cookies-from-browser).
 # The set version is for O(1) lookups, the list is for iteration.
-SUPPORTED_BROWSERS_SET: Set[str] = {
+SUPPORTED_BROWSERS_SET: set[str] = {
     "brave",
     "chrome",
     "chromium",
@@ -46,17 +47,17 @@ SUPPORTED_BROWSERS_SET: Set[str] = {
     "whale",
 }
 
-SUPPORTED_BROWSERS: List[str] = sorted(SUPPORTED_BROWSERS_SET)
+SUPPORTED_BROWSERS: list[str] = sorted(SUPPORTED_BROWSERS_SET)
 
 # === FILE VALIDATION ===
 # Minimum size for a valid cookie file (bytes)
 MIN_COOKIE_FILE_SIZE: int = 100
 
 # Video file extensions
-VIDEO_EXTENSIONS: Set[str] = {".mkv", ".mp4", ".webm", ".avi", ".mov"}
+VIDEO_EXTENSIONS: set[str] = {".mkv", ".mp4", ".webm", ".avi", ".mov"}
 
 # Subtitle file extensions
-SUBTITLE_EXTENSIONS: Set[str] = {".srt", ".vtt", ".ass", ".ssa"}
+SUBTITLE_EXTENSIONS: set[str] = {".srt", ".vtt", ".ass", ".ssa"}
 
 # === DOWNLOAD PROFILE CONSTANTS ===
 # Cache expiry for profile resolution (minutes)
@@ -83,13 +84,13 @@ LOGS_CONTAINER_STYLE: str = """
 
 # === PROGRESS REGEX PATTERNS ===
 # Patterns for parsing yt-dlp download progress output
-DOWNLOAD_PROGRESS_PATTERN: Pattern = re.compile(
+DOWNLOAD_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"\[download\]\s+(\d{1,3}\.\d+)%\s+of\s+([\d.]+\w+)\s+at\s+"
     r"([\d.]+\w+/s)\s+ETA\s+(\d{2}:\d{2})"
 )
 
-FRAGMENT_PROGRESS_PATTERN: Pattern = re.compile(
+FRAGMENT_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"\[download\]\s+Got fragment\s+(\d+)\s+of\s+(\d+)"
 )
 
-GENERIC_PERCENTAGE_PATTERN: Pattern = re.compile(r"(\d{1,3}(?:\.\d+)?)%")
+GENERIC_PERCENTAGE_PATTERN: re.Pattern[str] = re.compile(r"(\d{1,3}(?:\.\d+)?)%")

--- a/app/core.py
+++ b/app/core.py
@@ -5,7 +5,6 @@ This module contains the essential business logic for testing.
 
 import shlex
 from pathlib import Path
-from typing import Optional, Dict, List, Tuple
 
 from app.file_system_utils import is_valid_cookie_file
 
@@ -18,8 +17,8 @@ def build_base_ytdlp_command(
     embed_subs: bool,
     force_mp4: bool = False,
     custom_args: str = "",
-    quality_strategy: Optional[Dict] = None,
-) -> List[str]:
+    quality_strategy: dict | None = None,
+) -> list[str]:
     """Build base yt-dlp command with common options and premium quality strategies"""
 
     # Use premium strategy if provided
@@ -99,8 +98,8 @@ def build_base_ytdlp_command(
 
 
 def resolve_ytdlp_argument_conflicts(
-    base_args: List[str], custom_args: List[str]
-) -> List[str]:
+    base_args: list[str], custom_args: list[str]
+) -> list[str]:
     """
     Resolve conflicts between base yt-dlp arguments and custom arguments.
     Custom arguments take precedence over base arguments.
@@ -228,7 +227,7 @@ def build_cookies_params(
     browser_select: str = "chrome",
     browser_profile: str = "",
     cookies_file_path: str = "cookies/youtube_cookies.txt",
-) -> List[str]:
+) -> list[str]:
     """
     Builds cookie parameters based on configuration.
     Simplified version for testing without Streamlit dependencies.
@@ -258,7 +257,7 @@ def build_cookies_params(
         return ["--no-cookies"]
 
 
-def build_sponsorblock_params(sb_choice: str) -> List[str]:
+def build_sponsorblock_params(sb_choice: str) -> list[str]:
     """
     Builds yt-dlp parameters for SponsorBlock based on user choice.
     Simplified version for testing without Streamlit dependencies.
@@ -296,7 +295,7 @@ def build_sponsorblock_params(sb_choice: str) -> List[str]:
     return params
 
 
-def get_sponsorblock_config(sb_choice: str) -> Tuple[List[str], List[str]]:
+def get_sponsorblock_config(sb_choice: str) -> tuple[list[str], list[str]]:
     """
     Returns the SponsorBlock configuration based on user choice.
     Simplified version for testing without Streamlit dependencies.

--- a/app/cut_utils.py
+++ b/app/cut_utils.py
@@ -6,7 +6,7 @@ segment manipulation, and time remapping for SponsorBlock integration.
 """
 
 from pathlib import Path
-from typing import Dict, List, Callable, Tuple
+from collections.abc import Callable
 
 from app.translations import t
 from app.logs_utils import push_log_generic as push_log
@@ -108,7 +108,7 @@ def find_nearest_keyframes(
 # === SEGMENT MANIPULATION ===
 
 
-def merge_overlaps(segments: List[Dict], margin: float = 0.0) -> List[Dict]:
+def merge_overlaps(segments: list[dict], margin: float = 0.0) -> list[dict]:
     """Merge overlapping segments (keeping main 'sponsor' category as priority)."""
     segs = sorted(
         [
@@ -127,8 +127,8 @@ def merge_overlaps(segments: List[Dict], margin: float = 0.0) -> List[Dict]:
 
 
 def invert_segments(
-    segments: List[Dict], total_duration: float
-) -> List[Tuple[float, float]]:
+    segments: list[dict], total_duration: float
+) -> list[tuple[float, float]]:
     """
     Returns the intervals [start,end) to keep when removing 'segments'.
 
@@ -152,8 +152,8 @@ def invert_segments(
 
 
 def invert_segments_tuples(
-    segments: List[Tuple[int, int]], total_duration: int
-) -> List[Tuple[int, int]]:
+    segments: list[tuple[int, int]], total_duration: int
+) -> list[tuple[int, int]]:
     """
     LEGACY: Invert segments using tuple format (for backward compatibility).
 
@@ -192,8 +192,8 @@ def invert_segments_tuples(
 
 
 def build_time_remap(
-    segments: List[Dict], total_duration: float
-) -> Tuple[Callable[[float], float], List[Tuple[float, float, float]]]:
+    segments: list[dict], total_duration: float
+) -> tuple[Callable[[float], float], list[tuple[float, float, float]]]:
     """
     Builds a mapping original_time -> time_after_cut.
     Returns a `remap(t)` function + a list of cumulative jumps.
@@ -221,7 +221,7 @@ def build_time_remap(
 
 def remap_interval(
     start: float, end: float, remap: Callable[[float], float]
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     """Helper to recalculate an interval (start,end) after cutting"""
     s2 = remap(start)
     e2 = remap(end)
@@ -239,10 +239,10 @@ def build_cut_command(
     final_tmp: Path,
     actual_start: float,
     duration: float,
-    processed_subtitle_files: List[Tuple[str, Path]],
+    processed_subtitle_files: list[tuple[str, Path]],
     cut_output: Path,
     cut_ext: str,
-) -> List[str]:
+) -> list[str]:
     """
     Build the ffmpeg command for cutting video with subtitles.
 

--- a/app/display_utils.py
+++ b/app/display_utils.py
@@ -4,8 +4,6 @@ Display and formatting utilities.
 Functions for formatting time, durations, and other display-related utilities.
 """
 
-from typing import Optional
-
 
 def fmt_hhmmss(seconds: int) -> str:
     """
@@ -27,7 +25,7 @@ def fmt_hhmmss(seconds: int) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
 
-def parse_time_like(time_str: str) -> Optional[int]:
+def parse_time_like(time_str: str) -> int | None:
     """
     Parse a time-like string and return the duration in seconds.
     Accepts: "11" (sec), "0:11", "00:00:11", "1:02:03"
@@ -77,12 +75,12 @@ def build_info_items(
     platform_emoji: str,
     platform_name: str,
     media_type: str,
-    uploader: Optional[str] = None,
-    duration: Optional[int] = None,
-    view_count: Optional[int] = None,
-    like_count: Optional[int] = None,
-    entries_count: Optional[int] = None,
-    first_video_title: Optional[str] = None,
+    uploader: str | None = None,
+    duration: int | None = None,
+    view_count: int | None = None,
+    like_count: int | None = None,
+    entries_count: int | None = None,
+    first_video_title: str | None = None,
 ) -> list:
     """
     Build a list of formatted info items for display.

--- a/app/file_system_utils.py
+++ b/app/file_system_utils.py
@@ -8,7 +8,6 @@ including cleanup operations, directory listing, and file operations.
 import re
 import shutil
 from pathlib import Path
-from typing import List
 
 import streamlit as st
 from app.constants import SUPPORTED_BROWSERS_SET
@@ -115,7 +114,7 @@ def is_valid_browser(browser: str) -> bool:
 # === DIRECTORY OPERATIONS ===
 
 
-def list_subdirs_recursive(root: Path, max_depth: int = 2) -> List[str]:
+def list_subdirs_recursive(root: Path, max_depth: int = 2) -> list[str]:
     """
     List subdirectories recursively up to max_depth levels.
     Returns paths relative to root, formatted for display.

--- a/app/integrations_utils.py
+++ b/app/integrations_utils.py
@@ -5,7 +5,7 @@ Post-download integrations (e.g., Jellyfin refresh hooks).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from collections.abc import Callable
 
 import requests
 
@@ -20,14 +20,14 @@ class JellyfinScanResult:
 
     success: bool
     message: str
-    status_code: Optional[int] = None
+    status_code: int | None = None
 
 
 def trigger_jellyfin_library_scan(
     base_url: str,
     api_key: str,
-    session: Optional[requests.Session] = None,
-    log: Optional[Callable[[str], None]] = None,
+    session: requests.Session | None = None,
+    log: Callable[[str], None] | None = None,
 ) -> JellyfinScanResult:
     """
     Trigger a Jellyfin library scan (all libraries).

--- a/app/json_utils.py
+++ b/app/json_utils.py
@@ -10,18 +10,18 @@ across status_utils.py, url_utils.py, playlist_utils.py, etc.
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional, TypeVar, Union
+from typing import Any, TypeVar
 
 # Type alias for JSON-compatible data
-JsonData = Dict[str, Any]
+JsonData = dict[str, Any]
 T = TypeVar("T")
 
 
 def safe_load_json(
-    path: Union[Path, str],
-    default: Optional[T] = None,
+    path: Path | str,
+    default: T | None = None,
     log_errors: bool = True,
-) -> Optional[Union[JsonData, T]]:
+) -> JsonData | T | None:
     """
     Safely load JSON from a file with consistent error handling.
 
@@ -64,7 +64,7 @@ def safe_load_json(
 
 
 def safe_save_json(
-    path: Union[Path, str],
+    path: Path | str,
     data: JsonData,
     indent: int = 2,
     ensure_ascii: bool = False,
@@ -117,7 +117,7 @@ def safe_save_json(
         return False
 
 
-def json_file_exists(path: Union[Path, str]) -> bool:
+def json_file_exists(path: Path | str) -> bool:
     """
     Check if a JSON file exists and appears valid.
 
@@ -142,7 +142,7 @@ def json_file_exists(path: Union[Path, str]) -> bool:
 
 
 def update_json_file(
-    path: Union[Path, str],
+    path: Path | str,
     updates: JsonData,
     create_if_missing: bool = True,
     log_errors: bool = True,

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
 
 # Third-party imports
 import streamlit as st
@@ -185,7 +184,7 @@ def _display_strategy_content(quality_strategy: str) -> None:
         cached_format_ids = {p.get("format_id", "") for p in cached_profiles}
 
     # Helper function to check if a specific profile is cached and completed
-    def is_profile_cached(profile: Dict) -> bool:
+    def is_profile_cached(profile: dict) -> bool:
         """Check if a specific profile/format is downloaded and completed."""
         format_id = profile.get("format_id", "")
         return format_id in cached_format_ids
@@ -394,15 +393,15 @@ def smart_download_with_profiles(
     ytdlp_custom_args: str,
     url: str,
     download_mode: str,
-    target_profile: Optional[Union[str, Dict]] = None,
+    target_profile: str | dict | None = None,
     refuse_quality_downgrade: bool = False,
     do_cut: bool = False,
-    subs_selected: List[str] = None,
+    subs_selected: list[str] = None,
     sb_choice: str = "disabled",
     progress_placeholder=None,
     status_placeholder=None,
     info_placeholder=None,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     """
     Intelligent profile-based download with smart fallback strategy.
 
@@ -419,7 +418,7 @@ def smart_download_with_profiles(
         refuse_quality_downgrade: stop at first failure instead of trying lower quality
 
     Returns:
-        Tuple[int, str]: (return_code, error_message)
+        tuple[int, str]: (return_code, error_message)
     """
     safe_push_log("")
     log_title("🎯 Starting profile-based download...")
@@ -493,9 +492,9 @@ def smart_download_with_profiles(
 
 
 def _handle_profile_failure(
-    profile: Dict,
+    profile: dict,
     profile_idx: int,
-    profiles_to_try: List[Dict],
+    profiles_to_try: list[dict],
     download_mode: str,
     refuse_quality_downgrade: bool,
 ) -> bool:
@@ -532,9 +531,9 @@ def _handle_profile_failure(
 
 
 def _try_profile_with_clients(
-    cmd_base: List[str],
+    cmd_base: list[str],
     url: str,
-    cookies_part: List[str],
+    cookies_part: list[str],
     cookies_available: bool,
     status_placeholder,
     progress_placeholder,
@@ -624,16 +623,16 @@ def _try_profile_with_clients(
 
 
 def _build_profile_command(
-    profile: Dict,
+    profile: dict,
     base_output: str,
     tmp_video_dir: Path,
     embed_chapters: bool,
     embed_subs: bool,
     ytdlp_custom_args: str,
-    subs_selected: List[str],
+    subs_selected: list[str],
     do_cut: bool,
     sb_choice: str,
-) -> List[str]:
+) -> list[str]:
     """Build ytdlp command for a specific profile."""
     # Get format string from format_id (single source of truth)
     format_string = profile.get("format_id", "")
@@ -691,7 +690,7 @@ def _build_profile_command(
     return cmd_base
 
 
-def _get_profile_codec_info(profile: Dict) -> List[str]:
+def _get_profile_codec_info(profile: dict) -> list[str]:
     """Extract codec information from profile for display."""
     codec_info = []
 
@@ -720,24 +719,24 @@ def _get_profile_codec_info(profile: Dict) -> List[str]:
 
 
 def _execute_profile_downloads(
-    profiles_to_try: List[Dict],
+    profiles_to_try: list[dict],
     base_output: str,
     tmp_video_dir: Path,
     embed_chapters: bool,
     embed_subs: bool,
     ytdlp_custom_args: str,
     url: str,
-    cookies_part: List[str],
+    cookies_part: list[str],
     cookies_available: bool,
     refuse_quality_downgrade: bool,
     do_cut: bool,
-    subs_selected: List[str],
+    subs_selected: list[str],
     sb_choice: str,
     progress_placeholder,
     status_placeholder,
     info_placeholder,
     download_mode: str,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     """Execute download attempts for each profile."""
     log_title("🚀 Starting download attempts...")
     safe_push_log(f"profiles_to_try: {profiles_to_try}")
@@ -979,7 +978,7 @@ def init_url_workspace(
     clean_url: str,
     json_output_path: Path,
     tmp_url_workspace: Path,
-) -> Optional[Dict]:
+) -> dict | None:
     """
     Initialize workspace for a new URL by fetching video info and creating status files.
 
@@ -1033,7 +1032,7 @@ def init_url_workspace(
     return info
 
 
-def compute_optimal_profiles(url_info: Dict, json_path: Path) -> None:
+def compute_optimal_profiles(url_info: dict, json_path: Path) -> None:
     """
     Compute optimal format profiles for a VIDEO (not playlist).
     This function is called once after URL analysis to pre-calculate all profiles.
@@ -1122,7 +1121,7 @@ def initialize_video_workspace(
     video_id: str,
     video_title: str,
     video_workspace: Path,
-) -> Tuple[Optional[Dict], bool]:
+) -> tuple[dict | None, bool]:
     """
     Initialize a video workspace with url_info.json and status.json.
 
@@ -1139,7 +1138,7 @@ def initialize_video_workspace(
         video_workspace: Path to video workspace directory
 
     Returns:
-        Tuple[Optional[Dict], bool]: (url_info dict or None, success bool)
+        tuple[dict | None, bool]: (url_info dict or None, success bool)
     """
     video_url_info_path = video_workspace / "url_info.json"
     video_status_path = video_workspace / "status.json"
@@ -1198,8 +1197,8 @@ def initialize_video_workspace(
 
 def check_existing_video_file(
     video_workspace: Path,
-    requested_format_id: Optional[str] = None,
-) -> Tuple[Optional[Path], Optional[str]]:
+    requested_format_id: str | None = None,
+) -> tuple[Path | None, str | None]:
     """
     Check if a video file already exists in the workspace.
 
@@ -1213,7 +1212,7 @@ def check_existing_video_file(
         requested_format_id: Optional format ID requested by user
 
     Returns:
-        Tuple[Optional[Path], Optional[str]]: (existing_file_path or None, completed_format_id or None)
+        tuple[Path | None, str | None]: (existing_file_path or None, completed_format_id or None)
     """
     existing_generic_file = None
     completed_format_id = get_first_completed_format(video_workspace)
@@ -1278,13 +1277,13 @@ def download_single_video(
     force_mp4: bool,
     ytdlp_custom_args: str,
     do_cut: bool,
-    subs_selected: List[str],
+    subs_selected: list[str],
     sb_choice: str,
-    requested_format_id: Optional[str] = None,
+    requested_format_id: str | None = None,
     progress_placeholder=None,
     status_placeholder=None,
     info_placeholder=None,
-) -> Tuple[int, Optional[Path], Optional[str]]:
+) -> tuple[int, Path | None, str | None]:
     """
     Download a single video using the full workflow.
 
@@ -1313,7 +1312,7 @@ def download_single_video(
         info_placeholder: Streamlit info placeholder
 
     Returns:
-        Tuple[int, Optional[Path], Optional[str]]: (return_code, final_file_path, error_message)
+        tuple[int, Path | None, str | None]: (return_code, final_file_path, error_message)
         return_code: 0 = success, -1 = cancelled, >0 = error
     """
     # Initialize workspace
@@ -1388,7 +1387,7 @@ def download_single_video(
 def find_final_video_file(
     video_workspace: Path,
     base_output: str,
-) -> Optional[Path]:
+) -> Path | None:
     """
     Find the final video file after download.
 
@@ -1402,7 +1401,7 @@ def find_final_video_file(
         base_output: Base output filename (without extension)
 
     Returns:
-        Optional[Path]: Path to final file or None if not found
+        Path | None: Path to final file or None if not found
     """
     final_tmp = None
 
@@ -1438,7 +1437,7 @@ def organize_downloaded_video_file(
     video_workspace: Path,
     downloaded_file: Path,
     base_output: str,
-    subs_selected: List[str] = None,
+    subs_selected: list[str] = None,
 ) -> Path:
     """
     Organize downloaded video file: rename to generic name and create final.{ext}.
@@ -1555,7 +1554,7 @@ def organize_downloaded_video_file(
         return final_tmp
 
 
-def url_analysis(url: str) -> Optional[Dict]:
+def url_analysis(url: str) -> dict | None:
     """
     Analyze URL and fetch comprehensive video/playlist information using yt-dlp.
     Always initializes session state variables and checks for existing url_info.json.
@@ -1694,7 +1693,7 @@ def url_analysis(url: str) -> Optional[Dict]:
         return {"error": f"Unexpected error: {str(e)}"}
 
 
-def display_url_info(url_info: Dict) -> None:
+def display_url_info(url_info: dict) -> None:
     """
     Display URL analysis information in a user-friendly, visually appealing format.
 
@@ -1804,7 +1803,7 @@ def display_url_info(url_info: Dict) -> None:
         st.caption(t("url_invalid_content"))
 
 
-def get_url_info() -> Optional[Dict]:
+def get_url_info() -> dict | None:
     """
     Get the stored URL info from session state.
 
@@ -1814,7 +1813,7 @@ def get_url_info() -> Optional[Dict]:
     return st.session_state.get("url_info", None)
 
 
-def get_url_info_path() -> Optional[Path]:
+def get_url_info_path() -> Path | None:
     """
     Get the path to the saved URL info JSON file from session state.
 
@@ -1827,7 +1826,7 @@ def get_url_info_path() -> Optional[Path]:
     return None
 
 
-def get_tmp_url_workspace() -> Optional[Path]:
+def get_tmp_url_workspace() -> Path | None:
     """
     Get the unique URL workspace directory from session state.
     This directory is created during url_analysis() and stored in session.
@@ -1839,7 +1838,7 @@ def get_tmp_url_workspace() -> Optional[Path]:
     return st.session_state.get("tmp_url_workspace")
 
 
-def get_tmp_video_dir() -> Optional[Path]:
+def get_tmp_video_dir() -> Path | None:
     """
     Get the temporary video directory from session state.
 
@@ -1854,7 +1853,7 @@ def get_tmp_video_dir() -> Optional[Path]:
     return st.session_state.get("tmp_url_workspace")
 
 
-def build_cookies_params() -> List[str]:
+def build_cookies_params() -> list[str]:
     """
     Builds cookie parameters based on user selection.
 
@@ -1893,7 +1892,7 @@ def build_cookies_params() -> List[str]:
         return result
 
 
-def build_cookies_params_from_config() -> List[str]:
+def build_cookies_params_from_config() -> list[str]:
     """
     Builds cookie parameters from configuration settings (for early URL analysis).
     Used before session_state is available.
@@ -1990,7 +1989,7 @@ class DownloadMetrics:
 # Progress parsing utility functions (patterns imported from constants.py)
 
 
-def parse_download_progress(line: str) -> Optional[Tuple[float, str, str, str]]:
+def parse_download_progress(line: str) -> tuple[float, str, str, str] | None:
     """Parse download progress line and return (percentage, size, speed, eta)"""
     match = DOWNLOAD_PROGRESS_PATTERN.search(line)
     if match:
@@ -1998,7 +1997,7 @@ def parse_download_progress(line: str) -> Optional[Tuple[float, str, str, str]]:
     return None
 
 
-def parse_fragment_progress(line: str) -> Optional[Tuple[int, int]]:
+def parse_fragment_progress(line: str) -> tuple[int, int] | None:
     """Parse fragment progress and return (current, total)"""
     match = FRAGMENT_PROGRESS_PATTERN.search(line)
     if match:
@@ -2006,7 +2005,7 @@ def parse_fragment_progress(line: str) -> Optional[Tuple[int, int]]:
     return None
 
 
-def parse_generic_percentage(line: str) -> Optional[float]:
+def parse_generic_percentage(line: str) -> float | None:
     """Parse generic percentage from line"""
     if "download" in line:
         return None
@@ -3495,7 +3494,7 @@ def update_download_metrics(
         info_placeholder.info("📊 Processing...")
 
 
-def create_command_summary(cmd: List[str]) -> str:
+def create_command_summary(cmd: list[str]) -> str:
     """Create a user-friendly summary of the yt-dlp command instead of showing the full verbose command"""
     if not cmd or len(cmd) < 2:
         return "Running command..."
@@ -3536,7 +3535,7 @@ def create_command_summary(cmd: List[str]) -> str:
     return " • ".join(summary_parts)
 
 
-def run_cmd(cmd: List[str], progress=None, status=None, info=None) -> int:
+def run_cmd(cmd: list[str], progress=None, status=None, info=None) -> int:
     """Execute command with enhanced progress tracking and metrics display"""
     start_time = time.time()
 

--- a/app/medias_utils.py
+++ b/app/medias_utils.py
@@ -5,7 +5,6 @@ This module provides functions to analyze audio and video formats
 from yt-dlp JSON output to optimize download strategies.
 """
 
-from typing import Dict, List, Optional, Tuple
 from pathlib import Path
 import json
 import subprocess
@@ -34,11 +33,11 @@ s = get_settings()
 
 
 def analyze_audio_formats(
-    url_info: Dict,
+    url_info: dict,
     language_primary: str = "",
     languages_secondaries: str = "",
     vo_first: bool = True,
-) -> Tuple[Optional[str], List[Dict], bool]:
+) -> tuple[str | None, list[dict], bool]:
     """
     Analyze audio formats from yt-dlp JSON output to find the best quality audio tracks.
 
@@ -57,7 +56,7 @@ def analyze_audio_formats(
         vo_first: If True, prioritize original voice first
 
     Returns:
-        Tuple[Optional[str], List[Dict], bool]:
+        tuple[str | None, list[dict], bool]:
         - Original voice language code (or None if not detected)
         - List of filtered and ordered audio formats
         - Boolean indicating if multiple languages are available
@@ -248,8 +247,8 @@ YTDLP_FORMATS_SORT_VP9_FIRST_ARG = (
 
 
 def get_profiles_with_formats_id_to_download(
-    url_info_path: Path, multiple_langs: bool, audio_formats: List[Dict] = None
-) -> List[Dict]:
+    url_info_path: Path, multiple_langs: bool, audio_formats: list[dict] = None
+) -> list[dict]:
     """
     Determine optimal download profiles (max 2 profiles: AV1 and VP9).
     Returns complete profile dictionaries ready to use throughout the application.
@@ -404,7 +403,7 @@ def get_profiles_with_formats_id_to_download(
     return unique_profiles[:2]  # Maximum 2 profiles
 
 
-def get_audio_format_summary(audio_format: Dict) -> str:
+def get_audio_format_summary(audio_format: dict) -> str:
     """
     Get a human-readable summary of an audio format.
 
@@ -439,8 +438,8 @@ def get_audio_format_summary(audio_format: Dict) -> str:
 
 
 def analyze_video_formats(
-    url_info: Dict, max_resolution: Optional[int] = None
-) -> List[Dict]:
+    url_info: dict, max_resolution: int | None = None
+) -> list[dict]:
     """
     Analyze video formats from yt-dlp JSON output to find the best quality video tracks.
 
@@ -485,7 +484,7 @@ def analyze_video_formats(
         "h264": 1,  # H.264
     }
 
-    def get_codec_score(fmt: Dict) -> int:
+    def get_codec_score(fmt: dict) -> int:
         vcodec = fmt.get("vcodec", "").lower()
         for codec_prefix, score in codec_scores.items():
             if vcodec.startswith(codec_prefix):
@@ -507,7 +506,7 @@ def analyze_video_formats(
     return sorted_videos
 
 
-def get_format_details(url_info: Dict, format_id: str) -> Optional[Dict]:
+def get_format_details(url_info: dict, format_id: str) -> dict | None:
     """
     Get detailed information about a specific format.
 
@@ -529,7 +528,7 @@ def get_format_details(url_info: Dict, format_id: str) -> Optional[Dict]:
     return None
 
 
-def get_available_formats(url_info: Dict) -> List[Dict]:
+def get_available_formats(url_info: dict) -> list[dict]:
     """
     Extract all available video formats from url_info for user selection.
 
@@ -605,7 +604,7 @@ def get_available_formats(url_info: Dict) -> List[Dict]:
     return video_formats
 
 
-def group_audio_by_language(audio_formats: List[Dict]) -> Dict[str, List[Dict]]:
+def group_audio_by_language(audio_formats: list[dict]) -> dict[str, list[dict]]:
     """
     Group audio formats by language code.
 
@@ -626,7 +625,7 @@ def group_audio_by_language(audio_formats: List[Dict]) -> Dict[str, List[Dict]]:
     return grouped
 
 
-def get_best_audio_for_language(url_info: Dict, language: str = "en") -> Optional[Dict]:
+def get_best_audio_for_language(url_info: dict, language: str = "en") -> dict | None:
     """
     Get the best audio format for a specific language.
 
@@ -655,7 +654,7 @@ def get_best_audio_for_language(url_info: Dict, language: str = "en") -> Optiona
     return max(matching_audios, key=lambda x: x.get("abr", 0))
 
 
-def get_video_title_from_json(json_path: Optional[Path] = None) -> str:
+def get_video_title_from_json(json_path: Path | None = None) -> str:
     """
     Get video title from local url_info.json file.
 
@@ -711,7 +710,7 @@ def get_video_title_from_json(json_path: Optional[Path] = None) -> str:
         return "video"
 
 
-def get_video_title(url: str, cookies_part: List[str] = None) -> str:
+def get_video_title(url: str, cookies_part: list[str] = None) -> str:
     """
     Get video title with fallback strategy.
 
@@ -804,7 +803,7 @@ def get_video_title(url: str, cookies_part: List[str] = None) -> str:
         return "video"
 
 
-def get_video_duration_from_file(video_path: Path) -> Optional[int]:
+def get_video_duration_from_file(video_path: Path) -> int | None:
     """
     Get video duration in seconds from file using ffprobe.
 

--- a/app/multi_audio_utils.py
+++ b/app/multi_audio_utils.py
@@ -5,17 +5,16 @@ yt-dlp has issues with multi-language audio format strings, so we handle it manu
 
 import subprocess
 from pathlib import Path
-from typing import List, Dict, Tuple, Optional
 
 
 def download_video_and_audios_separately(
     url: str,
     video_format_id: str,
-    audio_formats: List[Dict],
+    audio_formats: list[dict],
     output_base: Path,
     temp_dir: Path,
-    cookies_args: List[str] = None,
-) -> Tuple[bool, Optional[Path]]:
+    cookies_args: list[str] = None,
+) -> tuple[bool, Path | None]:
     """
     Download video and multiple audio tracks separately, then merge with ffmpeg.
 

--- a/app/notifications.py
+++ b/app/notifications.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional
 import re
 
 from app.json_utils import safe_load_json, safe_save_json
@@ -36,8 +35,8 @@ class Notification:
     title: str
     message: str
     notification_type: NotificationType = NotificationType.INFO
-    action_label: Optional[str] = None  # Optional button label
-    action_url: Optional[str] = None  # Optional URL for the action
+    action_label: str | None = None  # Optional button label
+    action_url: str | None = None  # Optional URL for the action
     icon: str = "ℹ️"
 
 
@@ -160,7 +159,7 @@ def get_current_version() -> str:
         return "0.0.0"
 
 
-def get_latest_version() -> Optional[str]:
+def get_latest_version() -> str | None:
     """
     Get the latest version from GitHub releases.
 
@@ -177,7 +176,7 @@ def get_latest_version() -> Optional[str]:
 # === NOTIFICATION GENERATORS ===
 
 
-def check_update_notification() -> Optional[Notification]:
+def check_update_notification() -> Notification | None:
     """
     Check if there's a new major/minor version and return a notification.
 
@@ -213,7 +212,7 @@ def check_update_notification() -> Optional[Notification]:
     )
 
 
-def check_cleanup_notification_v260() -> Optional[Notification]:
+def check_cleanup_notification_v260() -> Notification | None:
     """
     One-time notification for v2.6.0 cleanup suggestion.
 
@@ -267,7 +266,7 @@ def check_cleanup_notification_v260() -> Optional[Notification]:
 # === MAIN NOTIFICATION ENGINE ===
 
 
-def get_active_notifications() -> List[Notification]:
+def get_active_notifications() -> list[Notification]:
     """
     Get all active notifications that should be displayed.
 

--- a/app/playlist_sync.py
+++ b/app/playlist_sync.py
@@ -15,7 +15,6 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from app.config import get_settings
 from app.file_system_utils import sanitize_filename, ensure_dir
@@ -78,10 +77,10 @@ class SyncAction:
     video_id: str
     title: str
     details: str = ""
-    old_path: Optional[Path] = None
-    new_path: Optional[Path] = None
-    old_index: Optional[int] = None
-    new_index: Optional[int] = None
+    old_path: Path | None = None
+    new_path: Path | None = None
+    old_index: int | None = None
+    new_index: int | None = None
 
 
 @dataclass
@@ -92,13 +91,13 @@ class PlaylistSyncPlan:
     playlist_title: str
 
     # Actions to perform
-    videos_to_rename: List[SyncAction] = field(default_factory=list)
-    videos_to_archive: List[SyncAction] = field(default_factory=list)
-    videos_to_delete: List[SyncAction] = field(default_factory=list)
-    videos_to_download: List[SyncAction] = field(default_factory=list)
-    videos_already_synced: List[SyncAction] = field(default_factory=list)
-    videos_to_relocate: List[SyncAction] = field(default_factory=list)
-    videos_ready_to_move: List[SyncAction] = field(
+    videos_to_rename: list[SyncAction] = field(default_factory=list)
+    videos_to_archive: list[SyncAction] = field(default_factory=list)
+    videos_to_delete: list[SyncAction] = field(default_factory=list)
+    videos_to_download: list[SyncAction] = field(default_factory=list)
+    videos_already_synced: list[SyncAction] = field(default_factory=list)
+    videos_to_relocate: list[SyncAction] = field(default_factory=list)
+    videos_ready_to_move: list[SyncAction] = field(
         default_factory=list
     )  # In tmp, ready to copy
 
@@ -143,7 +142,7 @@ class PlaylistSyncPlan:
 # === METADATA EXTRACTION ===
 
 
-def get_video_metadata_from_file(video_path: Path) -> Optional[Dict]:
+def get_video_metadata_from_file(video_path: Path) -> dict | None:
     """
     Extract metadata from a video file using ffprobe.
 
@@ -209,7 +208,7 @@ def get_video_metadata_from_file(video_path: Path) -> Optional[Dict]:
         return None
 
 
-def scan_destination_videos(dest_dir: Path) -> Dict[str, Dict]:
+def scan_destination_videos(dest_dir: Path) -> dict[str, dict]:
     """
     Scan destination directory and extract metadata from all video files.
 
@@ -239,7 +238,7 @@ def extract_title_from_pattern(
     pattern: str,
     index: int,
     total: int,
-) -> Optional[str]:
+) -> str | None:
     """
     Try to extract the original title from a filename based on a known pattern.
 
@@ -253,7 +252,7 @@ def extract_title_from_pattern(
 # === ARCHIVE URL_INFO ===
 
 
-def archive_url_info(playlist_workspace: Path) -> Optional[Path]:
+def archive_url_info(playlist_workspace: Path) -> Path | None:
     """
     Archive the current url_info.json before fetching a new one.
 
@@ -282,7 +281,7 @@ def archive_url_info(playlist_workspace: Path) -> Optional[Path]:
 def refresh_playlist_url_info(
     playlist_workspace: Path,
     playlist_url: str,
-) -> Optional[Dict]:
+) -> dict | None:
     """
     Refresh url_info.json by fetching the latest playlist data from YouTube.
 
@@ -371,11 +370,11 @@ def refresh_playlist_url_info(
 def sync_playlist(
     playlist_workspace: Path,
     dest_dir: Path,
-    new_url_info: Dict,
+    new_url_info: dict,
     new_location: str,
     new_pattern: str,
     dry_run: bool = True,
-    keep_old_videos: Optional[bool] = None,
+    keep_old_videos: bool | None = None,
 ) -> PlaylistSyncPlan:
     """
     Generate a synchronization plan for a playlist.
@@ -776,11 +775,11 @@ def sync_playlist(
 def _find_renamed_video(
     dest_dir: Path,
     video_id: str,
-    video_data: Dict,
+    video_data: dict,
     pattern: str,
     expected_index: int,
     total: int,
-) -> Optional[Dict]:
+) -> dict | None:
     """
     Try to find a video that was renamed by the user.
 
@@ -822,8 +821,8 @@ def apply_sync_plan(
     dest_dir: Path,
     new_location: str,
     new_pattern: str,
-    new_url_info: Dict,
-    keep_old_videos: Optional[bool] = None,
+    new_url_info: dict,
+    keep_old_videos: bool | None = None,
 ) -> bool:
     """
     Apply a synchronization plan to the filesystem and status.json.
@@ -1267,9 +1266,7 @@ def format_sync_plan_summary(plan: PlaylistSyncPlan) -> str:
     return "\n".join(lines)
 
 
-def format_sync_plan_details(
-    plan: PlaylistSyncPlan, channel: Optional[str] = None
-) -> str:
+def format_sync_plan_details(plan: PlaylistSyncPlan, channel: str | None = None) -> str:
     """
     Format detailed list of all sync actions.
 
@@ -1280,7 +1277,7 @@ def format_sync_plan_details(
     lines = []
 
     def format_title(
-        title: str, index: Optional[int] = None, include_channel: bool = True
+        title: str, index: int | None = None, include_channel: bool = True
     ) -> str:
         """Helper to format title with optional index and channel."""
         parts = []

--- a/app/playlist_utils.py
+++ b/app/playlist_utils.py
@@ -11,7 +11,6 @@ This module provides functions for handling YouTube playlists:
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 
 from app.file_system_utils import (
     sanitize_filename,
@@ -55,7 +54,7 @@ def is_playlist_url(url: str) -> bool:
     return False
 
 
-def extract_playlist_id(url: str) -> Optional[str]:
+def extract_playlist_id(url: str) -> str | None:
     """
     Extract playlist ID from YouTube playlist URL.
 
@@ -75,7 +74,7 @@ def extract_playlist_id(url: str) -> Optional[str]:
     return None
 
 
-def is_playlist_info(url_info: Dict) -> bool:
+def is_playlist_info(url_info: dict) -> bool:
     """
     Check if url_info represents a playlist.
 
@@ -96,7 +95,7 @@ def is_playlist_info(url_info: Dict) -> bool:
 # === PLAYLIST ENTRIES ===
 
 
-def get_playlist_entries(url_info: Dict) -> List[Dict]:
+def get_playlist_entries(url_info: dict) -> list[dict]:
     """
     Get list of video entries from playlist info.
 
@@ -120,7 +119,7 @@ def get_playlist_entries(url_info: Dict) -> List[Dict]:
     return result
 
 
-def get_playlist_video_count(url_info: Dict) -> int:
+def get_playlist_video_count(url_info: dict) -> int:
     """
     Get total video count from playlist info.
 
@@ -148,11 +147,11 @@ def get_playlist_video_count(url_info: Dict) -> int:
 
 def check_existing_videos_in_destination(
     dest_dir: Path,
-    playlist_entries: List[Dict],
-    video_extensions: List[str] = None,
-    playlist_workspace: Optional[Path] = None,
-    title_pattern: Optional[str] = None,
-) -> Tuple[List[Dict], List[Dict], int]:
+    playlist_entries: list[dict],
+    video_extensions: list[str] = None,
+    playlist_workspace: Path | None = None,
+    title_pattern: str | None = None,
+) -> tuple[list[dict], list[dict], int]:
     """
     Check which playlist videos already exist in destination folder.
 
@@ -305,8 +304,8 @@ def _normalize_for_comparison(name: str) -> str:
 
 
 def get_download_ratio(
-    already_downloaded: List[Dict],
-    to_download: List[Dict],
+    already_downloaded: list[dict],
+    to_download: list[dict],
 ) -> str:
     """
     Format the download ratio as a readable string.
@@ -324,8 +323,8 @@ def get_download_ratio(
 
 
 def get_download_progress_percent(
-    already_downloaded: List[Dict],
-    to_download: List[Dict],
+    already_downloaded: list[dict],
+    to_download: list[dict],
 ) -> float:
     """
     Calculate download progress as percentage.
@@ -418,8 +417,8 @@ def create_playlist_status(
     url: str,
     playlist_id: str,
     playlist_title: str,
-    entries: List[Dict],
-) -> Dict:
+    entries: list[dict],
+) -> dict:
     """
     Create initial status.json for a playlist.
 
@@ -468,7 +467,7 @@ def create_playlist_status(
     return status_data
 
 
-def load_playlist_status(playlist_workspace: Path) -> Optional[Dict]:
+def load_playlist_status(playlist_workspace: Path) -> dict | None:
     """
     Load playlist status from status.json.
 
@@ -481,7 +480,7 @@ def load_playlist_status(playlist_workspace: Path) -> Optional[Dict]:
     return safe_load_json(playlist_workspace / "status.json")
 
 
-def save_playlist_status(playlist_workspace: Path, status_data: Dict) -> bool:
+def save_playlist_status(playlist_workspace: Path, status_data: dict) -> bool:
     """
     Save playlist status to status.json.
 
@@ -500,8 +499,8 @@ def update_video_status_in_playlist(
     playlist_workspace: Path,
     video_id: str,
     status: str,
-    error: Optional[str] = None,
-    extra_data: Optional[Dict] = None,
+    error: str | None = None,
+    extra_data: dict | None = None,
 ) -> bool:
     """
     Update the status of a specific video in playlist status.
@@ -540,7 +539,7 @@ def update_video_status_in_playlist(
     return save_playlist_status(playlist_workspace, status_data)
 
 
-def get_playlist_progress(playlist_workspace: Path) -> Tuple[int, int, int, int]:
+def get_playlist_progress(playlist_workspace: Path) -> tuple[int, int, int, int]:
     """
     Get playlist download progress from status.json.
 
@@ -566,7 +565,7 @@ def get_playlist_progress(playlist_workspace: Path) -> Tuple[int, int, int, int]
     return completed, pending + skipped, failed, total
 
 
-def get_videos_to_download(playlist_workspace: Path) -> List[str]:
+def get_videos_to_download(playlist_workspace: Path) -> list[str]:
     """
     Get list of video IDs that still need to be downloaded.
 
@@ -622,7 +621,7 @@ def add_playlist_download_attempt(
     playlist_workspace: Path,
     custom_title: str,
     playlist_location: str,
-    title_pattern: Optional[str] = None,
+    title_pattern: str | None = None,
 ) -> bool:
     """
     Update playlist preferences in status.json.
@@ -664,7 +663,7 @@ def add_playlist_download_attempt(
     return save_playlist_status(playlist_workspace, status_data)
 
 
-def get_last_playlist_download_attempt(playlist_workspace: Path) -> Optional[Dict]:
+def get_last_playlist_download_attempt(playlist_workspace: Path) -> dict | None:
     """
     Get the current playlist preferences from status.json.
 
@@ -704,8 +703,8 @@ def copy_playlist_to_destination(
     playlist_workspace: Path,
     dest_dir: Path,
     playlist_name: str,
-    video_extensions: List[str] = None,
-) -> Tuple[int, int]:
+    video_extensions: list[str] = None,
+) -> tuple[int, int]:
     """
     Move all completed videos from their workspaces to destination folder.
 

--- a/app/process_utils.py
+++ b/app/process_utils.py
@@ -6,13 +6,13 @@ timeout management, and logging integration.
 """
 
 import subprocess
-from typing import List
+from collections.abc import Callable
 
 from app.logs_utils import safe_push_log
 
 
 def run_subprocess_safe(
-    cmd: List[str], timeout: int = 60, error_context: str = ""
+    cmd: list[str], timeout: int = 60, error_context: str = ""
 ) -> subprocess.CompletedProcess:
     """
     Run subprocess with standardized error handling and timeout.
@@ -46,7 +46,7 @@ def run_subprocess_safe(
         safe_push_log(f"⚠️ {error_msg}")
         # Return a fake result object for consistency
         return subprocess.CompletedProcess(cmd, 1, "", error_msg)
-    except Exception as e:
+    except OSError as e:
         error_msg = f"Command failed: {str(e)}"
         if error_context:
             error_msg = f"{error_context}: {error_msg}"
@@ -55,10 +55,10 @@ def run_subprocess_safe(
 
 
 def run_subprocess_with_progress(
-    cmd: List[str],
+    cmd: list[str],
     timeout: int = 300,
     error_context: str = "",
-    progress_callback: callable = None,
+    progress_callback: Callable[[str], None] | None = None,
 ) -> subprocess.CompletedProcess:
     """
     Run subprocess with optional progress monitoring.
@@ -121,7 +121,7 @@ def run_subprocess_with_progress(
             error_msg = f"{error_context}: {error_msg}"
         safe_push_log(f"⚠️ {error_msg}")
         return subprocess.CompletedProcess(cmd, 1, "", error_msg)
-    except Exception as e:
+    except OSError as e:
         error_msg = f"Command with progress monitoring failed: {str(e)}"
         if error_context:
             error_msg = f"{error_context}: {error_msg}"

--- a/app/profile_utils.py
+++ b/app/profile_utils.py
@@ -3,10 +3,8 @@ Utility functions for quality profile matching.
 Separated from main.py to avoid Streamlit imports in tests.
 """
 
-from typing import List, Dict, Optional
 
-
-def parse_format_line(line: str) -> Optional[Dict]:
+def parse_format_line(line: str) -> dict | None:
     """
     Parse a line from yt-dlp --list-formats output.
 
@@ -119,17 +117,17 @@ def parse_format_line(line: str) -> Optional[Dict]:
 
 
 def get_max_allowed_resolution(
-    video_quality_max: str, available_formats: List[Dict]
+    video_quality_max: str, available_formats: list[dict]
 ) -> int:
     """
-    Détermine la résolution maximale autorisée basée sur VIDEO_QUALITY_MAX.
+    Determine the maximum allowed resolution based on VIDEO_QUALITY_MAX.
 
     Args:
-        video_quality_max: Valeur de VIDEO_QUALITY_MAX ("max", "2160", "1440", "1080", etc.)
-        available_formats: Liste des formats vidéo disponibles
+        video_quality_max: Value of VIDEO_QUALITY_MAX ("max", "2160", "1440", "1080", etc.)
+        available_formats: List of available video formats
 
     Returns:
-        int: Résolution maximale autorisée en pixels (hauteur)
+        int: Maximum allowed resolution in pixels (height)
     """
     if not available_formats:
         return 1080  # Default fallback
@@ -154,29 +152,29 @@ def get_max_allowed_resolution(
 
 
 def match_profiles_to_formats(
-    formats: List[Dict], quality_profiles: List[Dict], video_quality_max: str = "max"
-) -> List[Dict]:
+    formats: list[dict], quality_profiles: list[dict], video_quality_max: str = "max"
+) -> list[dict]:
     """
-    Logique simple et prévisible de matching des profils.
+    Simple and predictable profile matching logic.
 
-    Pour chaque profil :
-    1. Trouve les 2 meilleurs formats vidéo qui correspondent aux codecs du profil
-    2. Trouve les 2 meilleurs formats audio qui correspondent aux codecs du profil
-    3. Crée toutes les combinaisons (2 vidéo × 2 audio = max 4 par profil)
-    4. Au total : 4 profils × 4 combinaisons = max 16 combinaisons
+    For each profile:
+    1. Find the 2 best video formats matching the profile's codecs
+    2. Find the 2 best audio formats matching the profile's codecs
+    3. Create all combinations (2 video × 2 audio = max 4 per profile)
+    4. Total: 4 profiles × 4 combinations = max 16 combinations
 
     Args:
-        formats: Liste des formats récupérés par get_video_formats()
-        quality_profiles: Liste des profils de qualité définis
-        video_quality_max: Résolution max autorisée ("max", "2160", "1080", etc.)
+        formats: List of formats retrieved by get_video_formats()
+        quality_profiles: List of defined quality profiles
+        video_quality_max: Maximum allowed resolution ("max", "2160", "1080", etc.)
 
     Returns:
-        Liste des combinaisons dans l'ordre strict de QUALITY_PROFILES
+        List of combinations in strict QUALITY_PROFILES order
     """
     if not formats or not quality_profiles:
         return []
 
-    # Séparer les formats vidéo et audio (formats purs uniquement)
+    # Separate video and audio formats (pure formats only)
     video_formats = [
         f for f in formats if f["vcodec"] != "none" and f["acodec"] == "none"
     ]
@@ -187,10 +185,10 @@ def match_profiles_to_formats(
     if not video_formats or not audio_formats:
         return []
 
-    # Déterminer la résolution max autorisée
+    # Determine the maximum allowed resolution
     max_resolution = get_max_allowed_resolution(video_quality_max, video_formats)
 
-    # Filtrer les formats vidéo à cette résolution
+    # Filter video formats to this resolution
     target_video_formats = [
         f for f in video_formats if f.get("height", 0) == max_resolution
     ]
@@ -198,7 +196,7 @@ def match_profiles_to_formats(
     if not target_video_formats:
         return []
 
-    # Trier tous les formats par qualité
+    # Sort all formats by quality
     target_video_formats.sort(
         key=lambda x: (x.get("fps", 0) or 0, x.get("vbr", 0) or x.get("tbr", 0) or 0),
         reverse=True,
@@ -207,11 +205,11 @@ def match_profiles_to_formats(
 
     all_combinations = []
 
-    # Pour chaque profil, trouver les formats compatibles
+    # For each profile, find compatible formats
     for profile in quality_profiles:
         profile_name = profile["name"]
 
-        # Trouver les 2 meilleurs formats vidéo pour ce profil
+        # Find the 2 best video formats for this profile
         matching_video_formats = []
         for video_spec in profile.get("video_codec_ext", []):
             required_video_codecs = video_spec.get("vcodec", [])
@@ -221,7 +219,7 @@ def match_profiles_to_formats(
                 fmt_codec = fmt["vcodec"]
                 fmt_ext = fmt["ext"]
 
-                # Vérifier si le codec correspond
+                # Check if codec matches
                 codec_match = False
                 for required_codec in required_video_codecs:
                     if (
@@ -232,20 +230,20 @@ def match_profiles_to_formats(
                         codec_match = True
                         break
 
-                # Vérifier l'extension si spécifiée
+                # Check extension if specified
                 ext_match = True
                 if allowed_video_exts and None not in allowed_video_exts:
                     ext_match = fmt_ext in allowed_video_exts
 
                 if codec_match and ext_match:
                     matching_video_formats.append(fmt)
-                    if len(matching_video_formats) >= 2:  # Max 2 formats vidéo
+                    if len(matching_video_formats) >= 2:  # Max 2 video formats
                         break
 
             if len(matching_video_formats) >= 2:
                 break
 
-        # Trouver les 2 meilleurs formats audio pour ce profil
+        # Find the 2 best audio formats for this profile
         matching_audio_formats = []
         for audio_spec in profile.get("audio_codec_ext", []):
             required_audio_codecs = audio_spec.get("acodec", [])
@@ -255,7 +253,7 @@ def match_profiles_to_formats(
                 fmt_codec = fmt["acodec"]
                 fmt_ext = fmt["ext"]
 
-                # Vérifier si le codec correspond
+                # Check if codec matches
                 codec_match = False
                 for required_codec in required_audio_codecs:
                     if fmt_codec == required_codec or (
@@ -264,20 +262,20 @@ def match_profiles_to_formats(
                         codec_match = True
                         break
 
-                # Vérifier l'extension si spécifiée
+                # Check extension if specified
                 ext_match = True
                 if allowed_audio_exts and None not in allowed_audio_exts:
                     ext_match = fmt_ext in allowed_audio_exts
 
                 if codec_match and ext_match:
                     matching_audio_formats.append(fmt)
-                    if len(matching_audio_formats) >= 2:  # Max 2 formats audio
+                    if len(matching_audio_formats) >= 2:  # Max 2 audio formats
                         break
 
             if len(matching_audio_formats) >= 2:
                 break
 
-        # Créer toutes les combinaisons pour ce profil (2×2 = max 4)
+        # Create all combinations for this profile (2×2 = max 4)
         if matching_video_formats and matching_audio_formats:
             for video_format in matching_video_formats:
                 for audio_format in matching_audio_formats:
@@ -298,8 +296,8 @@ def match_profiles_to_formats(
 
 
 def generate_profile_combinations(
-    profiles: List[Dict], formats: List[Dict], video_quality_max: str = "max"
-) -> List[Dict]:
+    profiles: list[dict], formats: list[dict], video_quality_max: str = "max"
+) -> list[dict]:
     """
     Generate combinations for specific profiles with available formats.
 

--- a/app/quality_profiles.py
+++ b/app/quality_profiles.py
@@ -15,7 +15,6 @@ NEW CODE SHOULD USE: medias_utils.get_profiles_with_formats_id_to_download() ins
 # Standard library
 import time
 import streamlit as st
-from typing import Dict, List, Optional, Tuple, Union
 
 from app.config import get_settings
 from app.process_utils import run_subprocess_safe
@@ -42,7 +41,7 @@ def get_cached_video_analysis(url: str):
 # run_subprocess_safe is now imported from logs_utils
 
 
-def parse_format_line(line: str) -> Optional[Dict]:
+def parse_format_line(line: str) -> dict | None:
     """Stub for profile_utils.parse_format_line"""
     from app.profile_utils import parse_format_line as pfl
 
@@ -146,8 +145,8 @@ QUALITY_PROFILES = [
 
 
 def get_video_formats(
-    url: str, cookies_part: List[str] = None
-) -> Tuple[bool, List[Dict], str]:
+    url: str, cookies_part: list[str] = None
+) -> tuple[bool, list[dict], str]:
     """
     Retrieve video format list from yt-dlp.
 
@@ -252,7 +251,7 @@ def get_video_formats(
 # === PROFILE MATCHING SYSTEM ===
 
 
-def extract_format_codecs(formats: List[Dict]) -> Dict:
+def extract_format_codecs(formats: list[dict]) -> dict:
     """
     Extract available codecs and their formats from yt-dlp format list.
 
@@ -309,8 +308,8 @@ def extract_format_codecs(formats: List[Dict]) -> Dict:
 
 
 def match_codec_requirements(
-    available_codecs: Dict, codec_ext_requirements: List[Dict]
-) -> List[Dict]:
+    available_codecs: dict, codec_ext_requirements: list[dict]
+) -> list[dict]:
     """
     Match available codecs against profile requirements.
 
@@ -365,7 +364,7 @@ def match_codec_requirements(
     return matches
 
 
-def match_profiles_to_formats_auto(formats: List[Dict]) -> List[Dict]:
+def match_profiles_to_formats_auto(formats: list[dict]) -> list[dict]:
     """
     Compatibility wrapper - match all QUALITY_PROFILES with available formats.
 
@@ -408,7 +407,7 @@ def match_profiles_to_formats_auto(formats: List[Dict]) -> List[Dict]:
     return combinations
 
 
-def get_optimal_profiles(formats: List[Dict], max_profiles: int = 10) -> List[Dict]:
+def get_optimal_profiles(formats: list[dict], max_profiles: int = 10) -> list[dict]:
     """
     Compatibility function - calls the new match_profiles_to_formats.
 
@@ -423,7 +422,7 @@ def get_optimal_profiles(formats: List[Dict], max_profiles: int = 10) -> List[Di
     return combinations[:max_profiles]
 
 
-def get_profile_availability_summary(formats: List[Dict]) -> Dict:
+def get_profile_availability_summary(formats: list[dict]) -> dict:
     """
     Get a summary of profile availability for UI display.
 
@@ -461,7 +460,7 @@ def get_profile_availability_summary(formats: List[Dict]) -> Dict:
     return summary
 
 
-def format_profile_for_display(combination: Dict) -> str:
+def format_profile_for_display(combination: dict) -> str:
     """
     Format a profile combination for user-friendly display.
 
@@ -487,8 +486,8 @@ def format_profile_for_display(combination: Dict) -> str:
 
 
 def analyze_video_formats_unified(
-    url: str, cookies_part: List[str]
-) -> Tuple[Dict[str, bool], List[Dict]]:
+    url: str, cookies_part: list[str]
+) -> tuple[dict[str, bool], list[dict]]:
     """
     Unified function that analyzes video formats and detects available codecs.
 
@@ -554,8 +553,8 @@ def analyze_video_formats_unified(
 
 
 def filter_viable_profiles(
-    available_codecs: Dict[str, bool], mode: str = "auto"
-) -> List[Dict]:
+    available_codecs: dict[str, bool], mode: str = "auto"
+) -> list[dict]:
     """
     Filter quality profiles based on available codecs.
 
@@ -622,7 +621,7 @@ def filter_viable_profiles(
     return sorted(viable_profiles, key=lambda x: x["priority"])
 
 
-def generate_format_string_from_profile(profile: Dict) -> str:
+def generate_format_string_from_profile(profile: dict) -> str:
     """
     Generate a yt-dlp format string from a modern profile structure.
 
@@ -685,7 +684,7 @@ def generate_format_string_from_profile(profile: Dict) -> str:
     return "/".join(combinations) + "/b*"  # Final fallback to any format
 
 
-def get_profile_by_name(profile_name: str) -> Optional[Dict]:
+def get_profile_by_name(profile_name: str) -> dict | None:
     """
     Get a quality profile by name (case-insensitive).
 
@@ -711,7 +710,7 @@ def get_profile_by_name(profile_name: str) -> Optional[Dict]:
     return None
 
 
-def format_profile_codec_info(profile: Dict) -> str:
+def format_profile_codec_info(profile: dict) -> str:
     """Format profile codec information for display."""
     # Extract video codecs
     video_codecs = []
@@ -758,7 +757,7 @@ def get_default_profile_index() -> int:
     return 0
 
 
-def get_download_configuration() -> Dict:
+def get_download_configuration() -> dict:
     """
     Centralized configuration retrieval from session state.
 
@@ -817,8 +816,8 @@ def show_download_failure_help(cookies_available: bool, profiles_count: int):
 
 
 def _get_video_analysis_cached(
-    url: str, cookies_part: List[str]
-) -> Tuple[Dict[str, bool], List[Dict]]:
+    url: str, cookies_part: list[str]
+) -> tuple[dict[str, bool], list[dict]]:
     """Get video format analysis with intelligent caching."""
     cached_url = st.session_state.get("codecs_detected_for_url", "")
     cache_timestamp = st.session_state.get("formats_detection_timestamp", 0)
@@ -859,10 +858,10 @@ def _get_video_analysis_cached(
 
 def resolve_download_profiles(
     download_mode: str,
-    target_profile: Optional[Union[str, Dict]],
-    available_formats: List[Dict],
-    available_codecs: Dict[str, bool],
-) -> Tuple[str, List[Dict], Optional[str]]:
+    target_profile: str | dict | None,
+    available_formats: list[dict],
+    available_codecs: dict[str, bool],
+) -> tuple[str, list[dict], str | None]:
     """
     Resolve which profiles to try for download based on mode and target.
 
@@ -913,8 +912,8 @@ def resolve_download_profiles(
 
 
 def _resolve_forced_profile(
-    target_profile: Union[str, Dict], available_formats: List[Dict]
-) -> Tuple[str, List[Dict], Optional[str]]:
+    target_profile: str | dict, available_formats: list[dict]
+) -> tuple[str, list[dict], str | None]:
     """Resolve a single forced profile."""
     if isinstance(target_profile, dict):
         # Dynamic profile from UI

--- a/app/sponsors_utils.py
+++ b/app/sponsors_utils.py
@@ -7,7 +7,6 @@ for skipping sponsor segments, introductions, outros, and other video segments.
 
 import json
 import requests
-from typing import Dict, List, Tuple
 from urllib.parse import urlparse
 
 from app.translations import t
@@ -114,8 +113,8 @@ def fetch_sponsorblock_segments(
 
 
 def get_sponsorblock_segments(
-    url: str, cookies_part: List[str], categories: List[str] = None
-) -> List[Dict]:
+    url: str, cookies_part: list[str], categories: list[str] = None
+) -> list[dict]:
     """
     Retrieves SponsorBlock segments from a video via direct API.
     Returns a list of segments with 'start' and 'end' in seconds.
@@ -206,8 +205,8 @@ def get_sponsorblock_segments(
 
 
 def calculate_sponsor_overlap(
-    start_sec: int, end_sec: int, sponsor_segments: List[Dict]
-) -> Tuple[int, int]:
+    start_sec: int, end_sec: int, sponsor_segments: list[dict]
+) -> tuple[int, int]:
     """
     Calculates total sponsor time in the requested section and adjusts the end.
 
@@ -282,7 +281,7 @@ def calculate_sponsor_overlap(
     return int(total_sponsor_time), int(adjusted_end)
 
 
-def get_sponsorblock_config(sb_choice: str) -> Tuple[List[str], List[str]]:
+def get_sponsorblock_config(sb_choice: str) -> tuple[list[str], list[str]]:
     """
     Returns the SponsorBlock configuration based on user choice or dynamic detection.
     Wrapper around core function with UI-specific dynamic sponsor detection.
@@ -317,7 +316,7 @@ def get_sponsorblock_config(sb_choice: str) -> Tuple[List[str], List[str]]:
     return core_get_sponsorblock_config(sb_choice)
 
 
-def build_sponsorblock_params(sb_choice: str) -> List[str]:
+def build_sponsorblock_params(sb_choice: str) -> list[str]:
     """
     Builds yt-dlp parameters for SponsorBlock based on user choice.
 

--- a/app/status_utils.py
+++ b/app/status_utils.py
@@ -7,7 +7,6 @@ and completion status for each video.
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from app.json_utils import safe_load_json, safe_save_json
 from app.logs_utils import safe_push_log
@@ -19,7 +18,7 @@ def create_initial_status(
     title: str,
     content_type: str,
     tmp_url_workspace: Path,
-) -> Dict:
+) -> dict:
     """
     Create initial status.json file for a video.
 
@@ -50,7 +49,7 @@ def create_initial_status(
     return status_data
 
 
-def load_status(tmp_url_workspace: Path) -> Optional[Dict]:
+def load_status(tmp_url_workspace: Path) -> dict | None:
     """
     Load status.json from the URL workspace directory.
 
@@ -63,7 +62,7 @@ def load_status(tmp_url_workspace: Path) -> Optional[Dict]:
     return safe_load_json(tmp_url_workspace / "status.json")
 
 
-def save_status(tmp_url_workspace: Path, status_data: Dict) -> bool:
+def save_status(tmp_url_workspace: Path, status_data: dict) -> bool:
     """
     Save status data to status.json.
 
@@ -83,7 +82,7 @@ def save_status(tmp_url_workspace: Path, status_data: Dict) -> bool:
 def add_selected_format(
     tmp_url_workspace: Path,
     video_format: str,
-    subtitles: List[str],
+    subtitles: list[str],
     filesize_approx: int,
 ) -> bool:
     """
@@ -203,7 +202,7 @@ def update_format_status(
     return save_status(tmp_url_workspace, status_data)
 
 
-def get_format_status(tmp_url_workspace: Path, video_format: str) -> Optional[str]:
+def get_format_status(tmp_url_workspace: Path, video_format: str) -> str | None:
     """
     Get the status of a specific format.
 
@@ -287,7 +286,7 @@ def mark_format_error(
     return save_status(tmp_url_workspace, status_data)
 
 
-def get_first_completed_format(tmp_url_workspace: Path) -> Optional[str]:
+def get_first_completed_format(tmp_url_workspace: Path) -> str | None:
     """
     Get the format ID of the first completed download.
 
@@ -331,7 +330,7 @@ def add_download_attempt(
     tmp_url_workspace: Path,
     custom_title: str,
     video_location: str,
-    requested_format_id: Optional[str] = None,
+    requested_format_id: str | None = None,
 ) -> bool:
     """
     Record a download attempt in status.json.
@@ -384,7 +383,7 @@ def add_download_attempt(
     return save_status(tmp_url_workspace, status_data)
 
 
-def get_last_download_attempt(tmp_url_workspace: Path) -> Optional[Dict]:
+def get_last_download_attempt(tmp_url_workspace: Path) -> dict | None:
     """
     Get the most recent download attempt from status.json.
 
@@ -410,8 +409,8 @@ def get_last_download_attempt(tmp_url_workspace: Path) -> Optional[Dict]:
 
 def get_profiles_cached(
     tmp_url_workspace: Path,
-    optimal_format_profiles: List[Dict],
-) -> List[Dict]:
+    optimal_format_profiles: list[dict],
+) -> list[dict]:
     """
     Get the list of optimal profiles that are cached (status = "completed").
 

--- a/app/subtitles_utils.py
+++ b/app/subtitles_utils.py
@@ -9,7 +9,6 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 from app.logs_utils import safe_push_log
 
@@ -17,9 +16,9 @@ from app.logs_utils import safe_push_log
 def find_subtitle_files_optimized(
     base_output: str,
     tmp_video_dir: Path,
-    subtitle_languages: List[str],
+    subtitle_languages: list[str],
     is_cut: bool = False,
-) -> List[Path]:
+) -> list[Path]:
     """
     Find subtitle files using optimized search patterns.
 
@@ -98,10 +97,10 @@ def find_subtitle_files_optimized(
 def process_subtitles_for_cutting(
     base_output: str,
     tmp_video_dir: Path,
-    subtitle_languages: List[str],
+    subtitle_languages: list[str],
     start_time: float,
     duration: float,
-) -> List[tuple]:
+) -> list[tuple]:
     """
     Process multiple subtitle files for video cutting.
 
@@ -311,7 +310,7 @@ def normalize_language_code(lang_code: str) -> str:
 
 
 def check_required_subtitles_embedded(
-    video_path: Path, required_languages: List[str]
+    video_path: Path, required_languages: list[str]
 ) -> bool:
     """
     Check if all required subtitle languages are embedded in the video.
@@ -390,7 +389,7 @@ def get_optimal_subtitle_codec(container_format: str) -> tuple:
         return "srt", True, "srt"  # Default fallback
 
 
-def get_language_names(lang_code: str) -> Tuple[str, str]:
+def get_language_names(lang_code: str) -> tuple[str, str]:
     """
     Get the ISO code and native name for a language.
 
@@ -543,7 +542,7 @@ def get_iso639_2_code(lang_code: str) -> str:
     return iso639_2_map.get(lang_code.lower(), "und")  # "und" = undefined
 
 
-def validate_subtitle_files(subtitle_files: List[Path]) -> List[Path]:
+def validate_subtitle_files(subtitle_files: list[Path]) -> list[Path]:
     """
     Validate a list of subtitle files and return only valid ones.
 
@@ -570,7 +569,7 @@ def validate_subtitle_files(subtitle_files: List[Path]) -> List[Path]:
     return valid_subtitle_files
 
 
-def create_backup_and_temp_paths(video_path: Path) -> Tuple[Path, Path]:
+def create_backup_and_temp_paths(video_path: Path) -> tuple[Path, Path]:
     """
     Create backup and temporary output paths for video processing.
 
@@ -612,7 +611,7 @@ def finalize_video_processing(
 
 
 def add_subtitle_metadata(
-    cmd: List[str], subtitle_files: List[Path], use_mp4_optimized: bool = False
+    cmd: list[str], subtitle_files: list[Path], use_mp4_optimized: bool = False
 ) -> None:
     """
     Add subtitle metadata to ffmpeg command.
@@ -652,7 +651,7 @@ def add_subtitle_metadata(
             safe_push_log(f"   📝 Subtitle {i+1}: {sub_file.name} → Unknown")
 
 
-def extract_language_from_filename(filename: str) -> Optional[str]:
+def extract_language_from_filename(filename: str) -> str | None:
     """
     Extract language code from subtitle filename using various patterns.
 
@@ -744,7 +743,7 @@ def validate_subtitle_file(subtitle_path: Path) -> bool:
 
 
 def embed_subtitles_manually_mp4_optimized(
-    video_path: Path, subtitle_files: List[Path]
+    video_path: Path, subtitle_files: list[Path]
 ) -> bool:
     """
     MP4-optimized subtitle embedding with enhanced metadata support.
@@ -818,7 +817,7 @@ def embed_subtitles_manually_mp4_optimized(
         return False
 
 
-def embed_subtitles_manually(video_path: Path, subtitle_files: List[Path]) -> bool:
+def embed_subtitles_manually(video_path: Path, subtitle_files: list[Path]) -> bool:
     """
     Manually embed subtitle files into video using ffmpeg with format-optimized settings.
 
@@ -998,8 +997,8 @@ def embed_subtitles_manually(video_path: Path, subtitle_files: List[Path]) -> bo
 
 
 def find_subtitle_files(
-    video_path: Path, search_patterns: Optional[List[str]] = None
-) -> List[Path]:
+    video_path: Path, search_patterns: list[str] | None = None
+) -> list[Path]:
     """
     Find subtitle files matching the video file.
 
@@ -1130,7 +1129,7 @@ def cut_subtitle_file(
 
 
 def ensure_subtitles_embedded(
-    video_path: Path, search_patterns: Optional[List[str]] = None
+    video_path: Path, search_patterns: list[str] | None = None
 ) -> bool:
     """
     Ensure subtitles are embedded in video file. If not, find and embed available subtitle files.

--- a/app/text_utils.py
+++ b/app/text_utils.py
@@ -7,7 +7,6 @@ consistent, filesystem-safe filenames from video titles.
 
 import re
 import unicodedata
-from typing import Optional
 
 # Windows reserved filenames (case-insensitive)
 _RESERVED = {
@@ -175,8 +174,8 @@ def render_title(
     title: str,
     video_id: str,
     ext: str,
-    total: Optional[int] = None,
-    channel: Optional[str] = None,
+    total: int | None = None,
+    channel: str | None = None,
 ) -> str:
     """
     Render a video title from a pattern with placeholders.

--- a/app/tmp_files.py
+++ b/app/tmp_files.py
@@ -35,7 +35,6 @@ Benefits:
 """
 
 from pathlib import Path
-from typing import Optional
 
 # Shared constant for video extensions used throughout the codebase
 VIDEO_EXTENSIONS = ["mkv", "mp4", "webm", "avi", "mov"]
@@ -182,7 +181,7 @@ def find_subtitles(tmp_dir: Path, is_cut: bool = False) -> list[Path]:
     return sorted(tmp_dir.glob(pattern))
 
 
-def find_final_file(tmp_dir: Path) -> Optional[Path]:
+def find_final_file(tmp_dir: Path) -> Path | None:
     """
     Find the final processed file in the temporary directory.
     Prioritizes MKV over other formats.
@@ -205,7 +204,7 @@ def find_final_file(tmp_dir: Path) -> Optional[Path]:
     return None
 
 
-def find_downloaded_video(tmp_dir: Path) -> Optional[Path]:
+def find_downloaded_video(tmp_dir: Path) -> Path | None:
     """
     Find ANY downloaded video file in the temporary directory.
 
@@ -257,7 +256,7 @@ def find_downloaded_video(tmp_dir: Path) -> Optional[Path]:
     return None
 
 
-def extract_format_id_from_filename(filename: str) -> Optional[str]:
+def extract_format_id_from_filename(filename: str) -> str | None:
     """
     Extract format ID from a video or audio track filename.
 
@@ -283,7 +282,7 @@ def extract_format_id_from_filename(filename: str) -> Optional[str]:
     return None
 
 
-def extract_language_from_subtitle(filename: str) -> Optional[str]:
+def extract_language_from_subtitle(filename: str) -> str | None:
     """
     Extract language code from a subtitle filename.
 

--- a/app/translations/__init__.py
+++ b/app/translations/__init__.py
@@ -3,7 +3,7 @@ Translation system for the YouTube downloader app
 """
 
 import os
-from typing import Dict, Any
+from typing import Any
 
 # Cache for translations to avoid repeated loading
 _translations_cache = None
@@ -22,7 +22,7 @@ def configure_language(language: str) -> None:
     _translations_cache = None  # Clear cache to force reload
 
 
-def get_translations() -> Dict[str, Any]:
+def get_translations() -> dict[str, Any]:
     """Get translations based on configured language or UI_LANGUAGE environment variable"""
     global _translations_cache
 

--- a/app/url_utils.py
+++ b/app/url_utils.py
@@ -8,7 +8,6 @@ without Streamlit dependencies, making them easy to test.
 import json
 import re
 from pathlib import Path
-from typing import Optional, Dict, Tuple
 
 from app.json_utils import safe_load_json, safe_save_json
 from app.logs_utils import safe_push_log
@@ -73,7 +72,7 @@ def video_id_from_url(url: str) -> str:
 # === URL INFO FILE OPERATIONS ===
 
 
-def load_url_info_from_file(file_path: Path) -> Optional[Dict]:
+def load_url_info_from_file(file_path: Path) -> dict | None:
     """
     Load URL info from a JSON file.
 
@@ -86,7 +85,7 @@ def load_url_info_from_file(file_path: Path) -> Optional[Dict]:
     return safe_load_json(file_path, log_errors=True)
 
 
-def save_url_info(json_path: Path, url_info: Dict) -> bool:
+def save_url_info(json_path: Path, url_info: dict) -> bool:
     """
     Save URL info to JSON file.
 
@@ -103,7 +102,7 @@ def save_url_info(json_path: Path, url_info: Dict) -> bool:
     return False
 
 
-def check_url_info_integrity(url_info: Dict) -> bool:
+def check_url_info_integrity(url_info: dict) -> bool:
     """
     Check if url_info contains premium formats (AV1 or VP9).
 
@@ -147,7 +146,7 @@ def check_url_info_integrity(url_info: Dict) -> bool:
 # === INTELLIGENT CACHING ===
 
 
-def is_url_info_complet(json_path: Path) -> Tuple[bool, Optional[Dict]]:
+def is_url_info_complet(json_path: Path) -> tuple[bool, dict | None]:
     """
     Check if existing url_info.json should be reused based on integrity.
 
@@ -163,9 +162,9 @@ def is_url_info_complet(json_path: Path) -> Tuple[bool, Optional[Dict]]:
         json_path: Path to url_info.json file
 
     Returns:
-        Tuple[bool, Optional[Dict]]:
+        tuple[bool, dict | None]:
         - bool: True if should reuse, False if should download
-        - Optional[Dict]: The loaded data if reusable, None otherwise
+        - dict | None: The loaded data if reusable, None otherwise
     """
     # Check if file exists
     if not json_path.exists():
@@ -219,7 +218,7 @@ def build_url_info(
     youtube_cookies_file_path: str = "",
     cookies_from_browser: str = "",
     youtube_clients: list = None,
-) -> Dict:
+) -> dict:
     """
     Download and build url_info.json with integrity checks and smart retries.
 
@@ -513,7 +512,7 @@ def build_url_info(
 
 def _build_bot_detection_error(
     youtube_cookies_file_path: str, cookies_from_browser: str
-) -> Dict:
+) -> dict:
     """Build helpful error message for bot detection."""
     from pathlib import Path
     from app.file_system_utils import is_valid_browser
@@ -559,7 +558,7 @@ def _build_bot_detection_error(
 
 def _build_age_restriction_error(
     youtube_cookies_file_path: str, cookies_from_browser: str
-) -> Dict:
+) -> dict:
     """Build helpful error message for age-restricted content."""
     from pathlib import Path
     from app.file_system_utils import is_valid_browser

--- a/app/workspace.py
+++ b/app/workspace.py
@@ -33,7 +33,6 @@ import hashlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Tuple
 
 
 @dataclass
@@ -250,7 +249,7 @@ def ensure_playlist_workspace(tmp_base: Path, platform: str, playlist_id: str) -
     return workspace
 
 
-def ensure_workspace_from_url(tmp_base: Path, url: str) -> Tuple[Path, UrlInfo]:
+def ensure_workspace_from_url(tmp_base: Path, url: str) -> tuple[Path, UrlInfo]:
     """
     Create and return workspace for a URL.
 
@@ -305,7 +304,7 @@ def get_legacy_folder_name(url: str) -> str:
     return f"{info.platform}-{info.id}"
 
 
-def extract_platform_and_id(folder_name: str) -> Optional[Tuple[str, str, str]]:
+def extract_platform_and_id(folder_name: str) -> tuple[str, str, str] | None:
     """
     Extract platform, ID and type from a legacy folder name.
 

--- a/app/ytdlp_version_check.py
+++ b/app/ytdlp_version_check.py
@@ -9,7 +9,6 @@ and display update information in the UI.
 import json
 import os
 import subprocess
-from typing import Optional
 
 import requests
 import streamlit as st
@@ -23,7 +22,7 @@ HOMETUBE_GITHUB_REPO = "EgalitarianMonkey/hometube"  # GitHub repository for Hom
 # === YT-DLP VERSION CHECK ===
 
 
-def get_current_ytdlp_version() -> Optional[str]:
+def get_current_ytdlp_version() -> str | None:
     """Get the currently installed yt-dlp version."""
     try:
         result = subprocess.run(
@@ -36,7 +35,7 @@ def get_current_ytdlp_version() -> Optional[str]:
     return None
 
 
-def get_latest_ytdlp_version() -> Optional[str]:
+def get_latest_ytdlp_version() -> str | None:
     """Get the latest yt-dlp version from GitHub API."""
     # Environment variable for testing
     test_version = os.getenv("TEST_LATEST_YTDLP_VERSION")
@@ -58,7 +57,7 @@ def get_latest_ytdlp_version() -> Optional[str]:
 # === HOMETUBE VERSION CHECK ===
 
 
-def get_current_hometube_version() -> Optional[str]:
+def get_current_hometube_version() -> str | None:
     """Get the current HomeTube version from pyproject.toml."""
     try:
         import tomllib
@@ -85,7 +84,7 @@ def get_current_hometube_version() -> Optional[str]:
     return None
 
 
-def get_latest_hometube_version() -> Optional[str]:
+def get_latest_hometube_version() -> str | None:
     """Get the latest HomeTube version from GitHub API."""
     # Environment variable for testing
     test_version = os.getenv("TEST_LATEST_HOMETUBE_VERSION")


### PR DESCRIPTION
- Updated type hints across multiple modules to use built-in types (e.g., `list`, `dict`, `tuple`) instead of `List`, `Dict`, and `Optional` from `typing`.
- Removed unnecessary imports of `Optional` and `Dict` where built-in types suffice.
- Ensured all functions and methods reflect the new type hinting style for better readability and maintainability.