### PR TITLE
fix(env): default .env.sample to Docker mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -38,10 +38,10 @@ YOUTUBE_COOKIES_FILE_PATH=/config/youtube_cookies.txt
 
 
 # --- Local run ---
-VIDEOS_FOLDER=./downloads
-TMP_DOWNLOAD_FOLDER=./tmp
+#VIDEOS_FOLDER=./downloads
+#TMP_DOWNLOAD_FOLDER=./tmp
 #YOUTUBE_COOKIES_FILE_PATH=./cookies/youtube_cookies.txt
-COOKIES_FROM_BROWSER=chrome
+#COOKIES_FROM_BROWSER=chrome
 
 
 # --- yt-dlp ---


### PR DESCRIPTION
Comment out the "Local run" overrides (VIDEOS_FOLDER, TMP_DOWNLOAD_FOLDER, COOKIES_FROM_BROWSER) so a default Docker setup using `env_file: .env` keeps the container paths (/data/videos, /data/tmp). These keys were defined twice, and with env_file the last value wins, so the local-run paths silently overrode the Docker ones — sending downloads inside the container instead of the mounted host volume. Uncomment them for a local (non-Docker) run.