### PR TITLE
chore(deps): enable Dependabot for uv, GitHub Actions and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Python dependencies managed by uv (pyproject.toml + uv.lock).
+  # The requirements/*.txt files are compiled artifacts of uv and are
+  # deliberately not tracked by a separate pip ecosystem entry.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Base image in Dockerfile (pinned to "latest" today, so PRs will be rare)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zurich"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly update checks (Mondays 06:00 Europe/Zurich):

- **uv** — Python dependencies via `pyproject.toml` + `uv.lock`, minor/patch updates grouped into a single PR. The `requirements/*.txt` files are uv-compiled artifacts and are intentionally not tracked separately.
- **github-actions** — actions used in `.github/workflows`, grouped.
- **docker** — base image in `Dockerfile` (currently `latest`, so PRs will be rare).