### PR TITLE
chore(deps): ignore pandas/numpy major bumps capped by streamlit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
       time: "06:00"
       timezone: "Europe/Zurich"
     open-pull-requests-limit: 5
+    ignore:
+      # Transitive deps of streamlit, which pins "pandas<3" and "numpy<3".
+      # Dependabot proposes their major bumps anyway and CI stays green
+      # (nothing imports them directly), but the resulting environment
+      # violates streamlit's own constraints. Revisit when the streamlit
+      # pin in pyproject.toml moves past a release that allows 3.x.
+      - dependency-name: "pandas"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
     groups:
       python-minor-patch:
         update-types:


### PR DESCRIPTION
streamlit 1.49 declares `pandas<3` and `numpy<3`. Dependabot proposed pandas 3.0.5 (#93) with green CI — nothing in `app/` or `tests/` imports pandas directly, so the test suite cannot catch it, but merging would leave an environment that violates streamlit's own constraint.

This adds an `ignore` entry for major bumps of both packages so the PR is not reopened every week. Minor and patch updates still flow normally.

Revisit once the `streamlit>=1.49,<1.51` pin in `pyproject.toml` moves to a release that allows 3.x.