### PR TITLE
fix(docker): restore pip in image build and cover it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,43 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  # The image is only ever built by release.yml (on a v* tag) and by the daily
+  # refresh-ytdlp.yml, and that refresh skips the build whenever the yt-dlp
+  # version is unchanged. A broken Dockerfile could therefore sit on main for
+  # weeks and only surface at release time — which is exactly what happened when
+  # the unpinned base image dropped its preinstalled pip. Build and smoke-test
+  # it on every PR instead. Single-arch here for speed; release.yml still does
+  # the full amd64+arm64 build.
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: hometube:ci
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image
+        run: |
+          docker run -d --name hometube-ci hometube:ci
+          for i in $(seq 1 24); do
+            status=$(docker inspect hometube-ci --format '{{.State.Health.Status}}')
+            [ "$status" = "healthy" ] && break
+            [ "$(docker inspect hometube-ci --format '{{.State.Status}}')" != "running" ] && break
+            sleep 5
+          done
+          docker logs hometube-ci
+          test "$(docker inspect hometube-ci --format '{{.State.Health.Status}}')" = "healthy"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-# Pin base by digest for reproducibility (arm64 digest shown)
+# Deliberately unpinned: refresh-ytdlp.yml rebuilds daily off this tag so a new
+# yt-dlp release reaches users without a manual bump. The trade-off is that the
+# base can change under us (it dropped a preinstalled pip and moved to Python
+# 3.14), so the install step below must not assume anything beyond python3.
 FROM jauderho/yt-dlp:latest
 
 # Static labels (common to all builds)
@@ -31,12 +34,14 @@ COPY pyproject.toml ./
 # One single RUN via Dockerfile heredoc (requires BuildKit)
 RUN <<'BASH'
 set -eux
-# Temporary build deps (watchdog may need a build on musllinux/aarch64)
-apk add --no-cache --virtual .build-deps build-base python3-dev
+# Temporary build deps (watchdog may need a build on musllinux/aarch64).
+# py3-pip is one of them: the base image ships python3 without pip.
+apk add --no-cache --virtual .build-deps build-base python3-dev py3-pip
 
-# Upgrade pip and install runtime deps
-pip install --no-cache-dir --upgrade pip --break-system-packages
-pip install --no-cache-dir --only-binary=:all: --no-binary=watchdog --no-compile ".[docker]" --break-system-packages
+# Upgrade pip and install runtime deps. Always go through "python3 -m pip":
+# the base provides no "pip" executable on PATH.
+python3 -m pip install --no-cache-dir --upgrade pip --break-system-packages
+python3 -m pip install --no-cache-dir --only-binary=:all: --no-binary=watchdog --no-compile ".[docker]" --break-system-packages
 
 # Remove heavy optional deps not needed by HomeTube
 python - <<'PY'


### PR DESCRIPTION
## The break

`docker build` off current `main` fails:

```
pip install --no-cache-dir --upgrade pip --break-system-packages
=> exit code 127
```

`jauderho/yt-dlp:latest` is deliberately unpinned so `refresh-ytdlp.yml` picks up new yt-dlp releases daily. That base has since moved to **Python 3.14.7** and **no longer ships a preinstalled pip** — `python3` is present, `pip` is not on PATH and `python3 -m pip` reports *No module named pip*.

## Why nobody noticed

The image is only built by `release.yml` (on a `v*` tag) and by `refresh-ytdlp.yml`, and that refresh **skips the build whenever the yt-dlp version is unchanged**. Every daily run since has reported success while skipping (`Versions match (2026.08.19)`). The next yt-dlp release — or the next tagged release — would have been the first failure.

## The fix

- Install `py3-pip` as a build dep and call `python3 -m pip` rather than the `pip` executable, so the install step assumes nothing beyond `python3`. `py3-pip` is part of `.build-deps` and is dropped again by `apk del`, so the runtime image is unchanged in size.
- Correct the misleading `# Pin base by digest` comment: the tag is floating **on purpose**, and the build must tolerate the base shifting under it.
- Add a `docker-build` CI job that builds and smoke-tests the image (waits for the container healthcheck) on every PR, so this class of break surfaces immediately instead of at release time. Single-arch for speed; `release.yml` still does the full amd64+arm64 build.

## Verified end to end

Built and run on a real amd64 Docker host from this branch's content:

- build succeeds on Python 3.14.7
- container reaches `healthy` in ~10s, `/_stcore/health` returns `ok`, `/` returns HTTP 200
- `app.main`, `app.notifications`, `app.core`, `app.medias_utils`, `app.playlist_sync`, `app.subtitles_utils` all import cleanly
- a real download (video+audio, ffmpeg merge) produced a valid 8 MB MP4, `ffprobe` duration 634.69s
- yt-dlp 2026.08.19 resolves formats identically to the running production container

Note: only `linux/amd64` was exercised. `py3-pip` is available on both Alpine arches, so `arm64` is expected to behave the same, but the first release build will be the real confirmation.