### PR TITLE
feat(notifications): announce Content in the app header

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -17,6 +17,8 @@ import re
 
 from app.json_utils import safe_load_json, safe_save_json
 
+CONTENT_REPO_URL = "https://github.com/LatentNoise/content"
+
 
 class NotificationType(Enum):
     """Types of notifications with associated styling."""
@@ -263,6 +265,35 @@ def check_cleanup_notification_v260() -> Notification | None:
     )
 
 
+def check_content_announcement() -> Notification | None:
+    """
+    Announcement for Content, the next generation of HomeTube.
+
+    Shown once per user until dismissed. HomeTube keeps running and being
+    maintained, so this stays an invitation rather than a deprecation warning.
+    """
+    notification_id = "content_announcement"
+
+    if is_notification_dismissed(notification_id):
+        return None
+
+    return Notification(
+        id=notification_id,
+        title="HomeTube has grown into a platform: Content",
+        message=(
+            "The same self-hosted idea, taken further — URLs, files and text in; "
+            "media, transcripts, summaries, translations and documents out. "
+            "It ships a HomeTube app of its own, plus Content Studio, a REST API, "
+            "a Python SDK and CLI, a browser extension, and an MCP server your AI "
+            "agents can drive. **This HomeTube keeps running, and stays maintained.**"
+        ),
+        notification_type=NotificationType.INFO,
+        action_label="Discover Content",
+        action_url=CONTENT_REPO_URL,
+        icon="🌱",
+    )
+
+
 # === MAIN NOTIFICATION ENGINE ===
 
 
@@ -284,6 +315,11 @@ def get_active_notifications() -> list[Notification]:
     cleanup_notif = check_cleanup_notification_v260()
     if cleanup_notif:
         notifications.append(cleanup_notif)
+
+    # Announce Content, the next generation of HomeTube
+    content_notif = check_content_announcement()
+    if content_notif:
+        notifications.append(content_notif)
 
     return notifications
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -13,6 +13,8 @@ from app.notifications import (
     dismiss_notification,
     check_update_notification,
     check_cleanup_notification_v260,
+    check_content_announcement,
+    CONTENT_REPO_URL,
 )
 
 
@@ -238,6 +240,48 @@ class TestCleanupNotification:
 
                 notif = check_cleanup_notification_v260()
                 assert notif is None
+
+
+class TestContentAnnouncement:
+    """Tests for the Content announcement."""
+
+    def test_announcement_shown_by_default(self, tmp_path):
+        """The announcement is offered until the user dismisses it."""
+        state_file = tmp_path / "notifications.json"
+
+        with patch(
+            "app.notifications.get_notifications_file_path", return_value=state_file
+        ):
+            notif = check_content_announcement()
+
+            assert notif is not None
+            assert notif.id == "content_announcement"
+            assert notif.action_url == CONTENT_REPO_URL
+            assert notif.notification_type == NotificationType.INFO
+
+    def test_no_announcement_when_dismissed(self, tmp_path):
+        """Dismissing the announcement keeps it hidden."""
+        state_file = tmp_path / "notifications.json"
+
+        with patch(
+            "app.notifications.get_notifications_file_path", return_value=state_file
+        ):
+            dismiss_notification("content_announcement")
+
+            assert check_content_announcement() is None
+
+    def test_announcement_does_not_deprecate_hometube(self, tmp_path):
+        """HomeTube stays maintained, so the wording must not read as an EOL notice."""
+        state_file = tmp_path / "notifications.json"
+
+        with patch(
+            "app.notifications.get_notifications_file_path", return_value=state_file
+        ):
+            notif = check_content_announcement()
+
+            assert "keeps running" in notif.message
+            for word in ("deprecated", "end of life", "sunset", "discontinued"):
+                assert word not in notif.message.lower()
 
 
 class TestNotificationDataclass:


### PR DESCRIPTION
Second step of `work/coming/00-Content-ad.md`. The README already carries the Content story; this brings it into the app itself, as the spec's "top notifications mentioning the new Content evolution".

## What it does

Adds `check_content_announcement()` to the existing notification engine, so the announcement renders at the top of the page through the same path as the update and cleanup notices — nothing new to maintain, and it inherits the ✕ dismiss button and its on-disk persistence.

- Dismissible, and dismissal sticks (stored in `user_notifications.json` like every other notification).
- Links to the Content repository via a new `CONTENT_REPO_URL` constant.
- No tracking parameters on the link, matching the plain URLs used in the README.

## Tone

The wording deliberately stays an **invitation, not a deprecation notice** — it closes on *"This HomeTube keeps running, and stays maintained"*, mirroring the README. A test asserts that, and guards against `deprecated` / `end of life` / `sunset` / `discontinued` creeping into the copy later.

## Verified

- 3 new unit tests; `tests/test_notifications.py` at 23 passed.
- Full suite: 307 passed, 6 skipped.
- `black --check` and `ruff check` clean.
- Rendered in the real app via `streamlit.testing.v1.AppTest`: the banner is the first info block on the page, with the working `Discover Content` link and no exception raised.