### PR TITLE
fix(ci): stop docker cache export races from failing the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
           tags: hometube:ci
           platforms: linux/amd64
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error keeps a cache-export race from failing the build: when a
+          # PR run and the main run export at the same time, one of them loses the
+          # reservation and buildx would otherwise abort an image that built fine.
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Smoke-test the image
         run: |


### PR DESCRIPTION
Follow-up to #98. The `docker-build` job already produced a false failure on `feat/content-announcement`:

```
#18 exporting to GitHub Actions Cache
#18 ERROR: failed to reserve cache
ERROR: failed to build: failed to solve: failed to reserve cache
```

The image had built successfully — the tarball was sent and the layer export was done. Only the **cache export** lost a reservation race against the concurrent `main` run, and buildx turns that into a build failure.

`ignore-error=true` on `cache-to` makes a lost cache export a warning instead. Worst case a run repopulates the cache; it can no longer fail an image that built cleanly.