### PR TITLE
chore(ci): match the docker action versions used by the release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false


### PR DESCRIPTION
The `docker-build` job added in #98 pinned `docker/setup-buildx-action@v3` and `docker/build-push-action@v6`, while #90 had already moved the rest of the repository to `@v4` and `@v7`.

That defeats part of the point of the job: it is meant to exercise the same image build the release performs, and it was exercising a different pair of actions. It would also have produced a redundant Dependabot PR on the next weekly run.

All twelve action tags referenced across `ci.yml`, `release.yml`, `build-image.yml` and `refresh-ytdlp.yml` were checked against their upstream repositories and all resolve, so nothing else in the release path is pointing at a version that does not exist.