### PR TITLE
chore(lint): state the ruff rule set explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,14 @@ extend-exclude = '''
 line-length = 88
 target-version = "py311"
 
+[tool.ruff.lint]
+# Ruff's historical default rule set, stated explicitly. Without this the
+# project inherits whatever ruff currently defaults to, so a routine version
+# bump silently widens what CI enforces — 0.16 did exactly that and turned a
+# dependency update into a repo-wide lint failure. Widen this list on purpose,
+# never by upgrading.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.coverage.run]
 source = ["app"]
 omit = ["*/tests/*","*/test_*","*/__pycache__/*","*/venv/*","*/.venv/*"]


### PR DESCRIPTION
`[tool.ruff]` sets only `line-length` and `target-version`, so the project inherits whatever rule set ruff currently defaults to. That makes the linter's strictness a function of the installed ruff version rather than a project decision.

Dependabot's grouped update (#101) bumps `ruff` 0.14.13 → 0.16.4, and 0.16 broadened those implicit defaults. CI on that PR fails with dozens of errors across files nobody touched — `I001` import sorting, `UP045`, `S110`, `BLE001` — none of which reflect a real change in the code:

```
tests/test_workspace.py:3:1: I001 Import block is un-sorted or un-formatted
tests/test_ytdlp_version_detection.py:238:20: BLE001 Do not catch blind exception
```

Declaring `select = ["E4", "E7", "E9", "F"]` — ruff's historical default — keeps CI enforcing exactly what it enforces today, and makes any future widening a deliberate edit instead of a side effect of a version bump. Verified locally: `ruff check app/ tests/` and `black --check` both clean with the explicit set.

This unblocks #101, which is the only Dependabot PR that refreshes `uv.lock` and so the one that clears most of the 148 open vulnerability alerts.

Adopting the new rules is a fine thing to do later — but as its own change, reviewed on its merits, not smuggled in by a lockfile update.