### PR TITLE
chore(deps): stop ignoring pandas majors now that streamlit allows them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,14 @@ updates:
       timezone: "Europe/Zurich"
     open-pull-requests-limit: 5
     ignore:
-      # Transitive deps of streamlit, which pins "pandas<3" and "numpy<3".
-      # Dependabot proposes their major bumps anyway and CI stays green
-      # (nothing imports them directly), but the resulting environment
-      # violates streamlit's own constraints. Revisit when the streamlit
-      # pin in pyproject.toml moves past a release that allows 3.x.
-      - dependency-name: "pandas"
-        update-types: ["version-update:semver-major"]
+      # numpy is a transitive dep of streamlit, which still pins "numpy<3".
+      # Dependabot proposes the major bump anyway and CI stays green (nothing
+      # imports numpy directly), but the resulting environment violates
+      # streamlit's own constraint. Drop this once streamlit allows 3.x.
+      #
+      # pandas used to be listed here for the same reason. streamlit 1.62
+      # widened its pin to "pandas<4", so major pandas updates are allowed
+      # again and are no longer ignored.
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
     groups:


### PR DESCRIPTION
#96 added an `ignore` entry for major pandas and numpy updates because streamlit 1.49 declared `pandas<3` and `numpy<3`, so Dependabot's pandas 3.0.5 PR would have produced an environment violating streamlit's own constraint despite green CI.

#101 moved streamlit to 1.62.0, which declares:

```
pandas<4,>=1.4.0
numpy<3,>=1.23
pillow<13,>=7.1.0
```

The pandas reason is therefore gone — majors are allowed again — and keeping the rule would silently hold the project back on a dependency nothing actually blocks. numpy is still capped at `<3`, so its entry stays.

(The same widening is why the pillow 12.3.0 security update could be taken in #104: streamlit 1.49 capped pillow at `<12`, 1.62 allows `<13`.)