### PR TITLE
feat(notifications): re-offer the Content announcement each feature release

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -265,14 +265,29 @@ def check_cleanup_notification_v260() -> Notification | None:
     )
 
 
+def get_content_announcement_id(version: str | None = None) -> str:
+    """
+    Build the announcement id for a given HomeTube version.
+
+    The id carries only major.minor, so dismissing the announcement silences it
+    for the release at hand and every patch on top of it, and the next feature
+    release brings it back under a new id. That mirrors the rule the update
+    notification already follows: patch releases stay silent.
+    """
+    parts = (version or get_current_version()).split(".")
+    return f"content_announcement_v{'.'.join(parts[:2])}"
+
+
 def check_content_announcement() -> Notification | None:
     """
-    Announcement for Content, the next generation of HomeTube.
+    Announcement for Content, the platform HomeTube grew into.
 
-    Shown once per user until dismissed. HomeTube keeps running and being
-    maintained, so this stays an invitation rather than a deprecation warning.
+    Re-offered once per feature release rather than once ever: someone who
+    dismissed it a year ago should still hear about what Content became. It
+    stays a single, dismissible line — an invitation, never a deprecation
+    warning, since HomeTube keeps being developed.
     """
-    notification_id = "content_announcement"
+    notification_id = get_content_announcement_id()
 
     if is_notification_dismissed(notification_id):
         return None
@@ -285,7 +300,7 @@ def check_content_announcement() -> Notification | None:
             "media, transcripts, summaries, translations and documents out. "
             "It ships a HomeTube app of its own, plus Content Studio, a REST API, "
             "a Python SDK and CLI, a browser extension, and an MCP server your AI "
-            "agents can drive. **This HomeTube keeps running, and stays maintained.**"
+            "agents can drive. **HomeTube keeps running, and keeps being developed.**"
         ),
         notification_type=NotificationType.INFO,
         action_label="Discover Content",

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -14,6 +14,7 @@ from app.notifications import (
     check_update_notification,
     check_cleanup_notification_v260,
     check_content_announcement,
+    get_content_announcement_id,
     CONTENT_REPO_URL,
 )
 
@@ -255,7 +256,7 @@ class TestContentAnnouncement:
             notif = check_content_announcement()
 
             assert notif is not None
-            assert notif.id == "content_announcement"
+            assert notif.id == get_content_announcement_id()
             assert notif.action_url == CONTENT_REPO_URL
             assert notif.notification_type == NotificationType.INFO
 
@@ -266,9 +267,43 @@ class TestContentAnnouncement:
         with patch(
             "app.notifications.get_notifications_file_path", return_value=state_file
         ):
-            dismiss_notification("content_announcement")
+            dismiss_notification(get_content_announcement_id())
 
             assert check_content_announcement() is None
+
+    def test_id_tracks_the_minor_version(self):
+        """The id carries major.minor, so patches share it and minors do not."""
+        assert get_content_announcement_id("2.11.0") == "content_announcement_v2.11"
+        assert get_content_announcement_id("2.11.4") == get_content_announcement_id(
+            "2.11.0"
+        )
+        assert get_content_announcement_id("2.12.0") != get_content_announcement_id(
+            "2.11.0"
+        )
+        assert get_content_announcement_id("3.0.0") != get_content_announcement_id(
+            "2.11.0"
+        )
+
+    def test_reappears_after_a_feature_release(self, tmp_path):
+        """A dismissal covers its own release and its patches, not the next minor."""
+        state_file = tmp_path / "notifications.json"
+
+        with patch(
+            "app.notifications.get_notifications_file_path", return_value=state_file
+        ):
+            with patch("app.notifications.get_current_version", return_value="2.11.0"):
+                dismiss_notification(get_content_announcement_id())
+                assert check_content_announcement() is None
+
+            # A patch on top of it stays silent.
+            with patch("app.notifications.get_current_version", return_value="2.11.3"):
+                assert check_content_announcement() is None
+
+            # The next feature release offers it again.
+            with patch("app.notifications.get_current_version", return_value="2.12.0"):
+                notif = check_content_announcement()
+                assert notif is not None
+                assert notif.id == "content_announcement_v2.12"
 
     def test_announcement_does_not_deprecate_hometube(self, tmp_path):
         """HomeTube stays maintained, so the wording must not read as an EOL notice."""


### PR DESCRIPTION
Implements the recurrence part of `work/coming/03-Smart Content notification.md`. The announcement shipped in #99 could be dismissed exactly once, forever — someone who dismissed it early would never hear about what Content became.

The notification id now carries `major.minor` (`content_announcement_v2.11`), so:

- dismissing it silences it for that release **and every patch on top of it**;
- the next feature release offers it again, once.

Patch releases staying quiet is deliberate — it matches the rule the update notification already follows, documented in `docs/releasing.md`: *"the in-app 'New version available!' notification only triggers for major/minor updates, so patch releases are silent"*. A user who says "not now" is not asked again until there is genuinely something new.

It remains a single dismissible line at the top of the page, and the wording stays an invitation: the closing sentence is now **"HomeTube keeps running, and keeps being developed"** — no deprecation, no migration deadline. The existing guard test still forbids `deprecated` / `end of life` / `sunset` / `discontinued` in the copy.

The spec also anticipates dialling the intensity up later. This change deliberately does **not** do that — it stays at one quiet line, and the per-release id is the hook that makes escalation possible without re-plumbing anything.

## Verified

- 4 new tests covering the id format, patch equivalence, minor/major differentiation, and the dismiss-then-reappear cycle across 2.11.0 → 2.11.3 → 2.12.0.
- `tests/test_notifications.py`: 25 passed. Full suite: 309 passed, 6 skipped.
- `black --check` and `ruff check` clean.