### PR TITLE
chore(release): bump version to 2.11.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,5 +2,5 @@
 HomeTube - YouTube Video Downloader with Streamlit UI
 """
 
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 __author__ = "Yann ORIEULT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hometube"
-version = "2.10.0"
+version = "2.11.0"
 description = "HomeTube development workspace"
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "hometube"
-version = "2.10.0"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Release preparation for **v2.11.0**. A minor bump: new user-visible behaviour (the Content announcement), no breaking change to configuration, volumes or defaults.

Updates `pyproject.toml`, `app/__init__.py` and the `hometube` entry in `uv.lock` — the three files `make version-update` touches. It was done by hand because `uv` is not installed on this machine; for a version-only change `uv lock` rewrites exactly that one `version` field, and the result was diffed to confirm nothing else moved.

Being a minor release, this also triggers the in-app *New version available!* notice for running instances, per `docs/releasing.md`.

Verified: 309 passed, 6 skipped, and `get_content_announcement_id()` now resolves to `content_announcement_v2.11`, so the Content announcement is offered once on this release.