### PR TITLE
feat(notifications): show one notification at a time and slim the Content note

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -278,14 +278,33 @@ def get_content_announcement_id(version: str | None = None) -> str:
     return f"content_announcement_v{'.'.join(parts[:2])}"
 
 
+# One concrete capability per release rather than the same pitch every time.
+# These are written for people who already run their own containers: a specific
+# thing the engine does, in one line, with no adjectives to sell it. The angle
+# rotates with the minor version, so a returning user meets a new detail instead
+# of a banner they have already read and ignored.
+CONTENT_ANGLES = (
+    "It speaks MCP, so Claude, your IDE or any agent can drive your library.",
+    "REST API, CLI and a typed Python SDK — scriptable from anything that speaks HTTP.",
+    "Beyond video: transcripts, summaries, translations and documents, from URLs, files or plain text.",
+)
+
+
+def get_content_angle(version: str | None = None) -> str:
+    """Pick this release's angle, deterministically, from the minor version."""
+    minor = parse_version(version or get_current_version())[1]
+    return CONTENT_ANGLES[minor % len(CONTENT_ANGLES)]
+
+
 def check_content_announcement() -> Notification | None:
     """
-    Announcement for Content, the platform HomeTube grew into.
+    A one-line note about Content, the engine HomeTube grew into.
 
-    Re-offered once per feature release rather than once ever: someone who
-    dismissed it a year ago should still hear about what Content became. It
-    stays a single, dismissible line — an invitation, never a deprecation
-    warning, since HomeTube keeps being developed.
+    Deliberately shaped like the update notice rather than like an ad: same
+    length, same weight, one concrete fact and a link. It is offered once per
+    feature release — someone who dismissed it a year ago should still hear
+    what Content became — and never alongside another notification, see
+    get_active_notifications().
     """
     notification_id = get_content_announcement_id()
 
@@ -294,16 +313,10 @@ def check_content_announcement() -> Notification | None:
 
     return Notification(
         id=notification_id,
-        title="HomeTube has grown into a platform: Content",
-        message=(
-            "The same self-hosted idea, taken further — URLs, files and text in; "
-            "media, transcripts, summaries, translations and documents out. "
-            "It ships a HomeTube app of its own, plus Content Studio, a REST API, "
-            "a Python SDK and CLI, a browser extension, and an MCP server your AI "
-            "agents can drive. **HomeTube keeps running, and keeps being developed.**"
-        ),
+        title="Content — where HomeTube goes next",
+        message=get_content_angle(),
         notification_type=NotificationType.INFO,
-        action_label="Discover Content",
+        action_label="Take a look",
         action_url=CONTENT_REPO_URL,
         icon="🌱",
     )
@@ -314,29 +327,31 @@ def check_content_announcement() -> Notification | None:
 
 def get_active_notifications() -> list[Notification]:
     """
-    Get all active notifications that should be displayed.
+    Return at most one notification, the most useful one right now.
 
-    This function checks all notification sources and returns
-    only the ones that haven't been dismissed.
+    Stacking is what makes a header feel invasive: two banners at once read as
+    clutter no matter how politely each is worded. So the sources are ranked and
+    the first match wins.
+
+    The order is by what the user gains from acting on it. A pending update is
+    time-sensitive and about the thing they are already running, so it outranks
+    everything. The Content note is an invitation with no deadline, so it waits
+    its turn — and lands naturally on the visit *after* an upgrade, when there
+    is no update left to report. Housekeeping comes last; it is never urgent.
+
+    Anything skipped is not lost: it surfaces once whatever outranked it is
+    dismissed or no longer applies.
     """
-    notifications = []
+    for check in (
+        check_update_notification,
+        check_content_announcement,
+        check_cleanup_notification_v260,
+    ):
+        notification = check()
+        if notification:
+            return [notification]
 
-    # Check for update notification
-    update_notif = check_update_notification()
-    if update_notif:
-        notifications.append(update_notif)
-
-    # Check for v2.6.0 cleanup notification
-    cleanup_notif = check_cleanup_notification_v260()
-    if cleanup_notif:
-        notifications.append(cleanup_notif)
-
-    # Announce Content, the next generation of HomeTube
-    content_notif = check_content_announcement()
-    if content_notif:
-        notifications.append(content_notif)
-
-    return notifications
+    return []
 
 
 def render_notifications_streamlit() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,5 +1,6 @@
 """Tests for the notification engine."""
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from app.notifications import (
@@ -15,6 +16,9 @@ from app.notifications import (
     check_cleanup_notification_v260,
     check_content_announcement,
     get_content_announcement_id,
+    get_content_angle,
+    get_active_notifications,
+    CONTENT_ANGLES,
     CONTENT_REPO_URL,
 )
 
@@ -305,18 +309,108 @@ class TestContentAnnouncement:
                 assert notif is not None
                 assert notif.id == "content_announcement_v2.12"
 
-    def test_announcement_does_not_deprecate_hometube(self, tmp_path):
-        """HomeTube stays maintained, so the wording must not read as an EOL notice."""
-        state_file = tmp_path / "notifications.json"
+    def test_no_angle_deprecates_hometube(self):
+        """HomeTube stays maintained, so no angle may read as an EOL notice."""
+        for angle in CONTENT_ANGLES:
+            lowered = angle.lower()
+            for word in (
+                "deprecated",
+                "end of life",
+                "sunset",
+                "discontinued",
+                "migrate",
+                "instead of hometube",
+                "replaces",
+            ):
+                assert word not in lowered, f"{word!r} in {angle!r}"
+
+    def test_angles_stay_one_line(self):
+        """The note earns its subtlety by being as short as the update notice."""
+        for angle in CONTENT_ANGLES:
+            assert len(angle) <= 110, f"{len(angle)} chars: {angle!r}"
+            assert angle.count(".") <= 2
+
+    def test_angle_rotates_with_the_release(self):
+        """A returning user meets a new detail, not the banner they already read."""
+        seen = [get_content_angle(f"2.{minor}.0") for minor in range(11, 17)]
+
+        assert len(set(seen)) == len(CONTENT_ANGLES)
+        assert get_content_angle("2.11.0") == get_content_angle("2.11.9")
+        assert get_content_angle("2.11.0") != get_content_angle("2.12.0")
+
+
+class TestOneNotificationAtATime:
+    """Stacked banners are what makes a header invasive — only one may show."""
+
+    @contextmanager
+    def _state(self, tmp_path):
+        """Isolate both the dismissal file and the tmp folder.
+
+        The cleanup notification inspects the real configured tmp folder, so
+        without pinning it here this suite would see whatever other tests left
+        behind and the ranking assertions would depend on execution order.
+        """
+        tmp_folder = tmp_path / "tmp"
+        tmp_folder.mkdir()
 
         with patch(
-            "app.notifications.get_notifications_file_path", return_value=state_file
+            "app.notifications.get_notifications_file_path",
+            return_value=tmp_path / "notifications.json",
         ):
-            notif = check_content_announcement()
+            with patch(
+                "app.config.ensure_folders_exist",
+                return_value=(tmp_path / "videos", tmp_folder),
+            ):
+                yield
 
-            assert "keeps running" in notif.message
-            for word in ("deprecated", "end of life", "sunset", "discontinued"):
-                assert word not in notif.message.lower()
+    def test_update_outranks_the_content_note(self, tmp_path):
+        """A pending update is time-sensitive, so it wins and Content waits."""
+        with self._state(tmp_path):
+            with patch("app.notifications.get_current_version", return_value="2.11.0"):
+                with patch(
+                    "app.notifications.get_latest_version", return_value="2.12.0"
+                ):
+                    active = get_active_notifications()
+
+                    assert len(active) == 1
+                    assert active[0].id == "update_2.12.0"
+
+    def test_content_note_surfaces_once_the_update_is_dismissed(self, tmp_path):
+        """Nothing is lost — what was outranked appears next."""
+        with self._state(tmp_path):
+            with patch("app.notifications.get_current_version", return_value="2.11.0"):
+                with patch(
+                    "app.notifications.get_latest_version", return_value="2.12.0"
+                ):
+                    dismiss_notification("update_2.12.0")
+
+                    active = get_active_notifications()
+
+                    assert len(active) == 1
+                    assert active[0].id == "content_announcement_v2.11"
+
+    def test_content_note_after_upgrading(self, tmp_path):
+        """On the visit after an upgrade there is no update left, so Content shows."""
+        with self._state(tmp_path):
+            with patch("app.notifications.get_current_version", return_value="2.12.0"):
+                with patch(
+                    "app.notifications.get_latest_version", return_value="2.12.0"
+                ):
+                    active = get_active_notifications()
+
+                    assert len(active) == 1
+                    assert active[0].id == "content_announcement_v2.12"
+
+    def test_nothing_when_everything_is_dismissed(self, tmp_path):
+        """A quiet header is the normal state."""
+        with self._state(tmp_path):
+            with patch("app.notifications.get_current_version", return_value="2.12.0"):
+                with patch(
+                    "app.notifications.get_latest_version", return_value="2.12.0"
+                ):
+                    dismiss_notification("content_announcement_v2.12")
+
+                    assert get_active_notifications() == []
 
 
 class TestNotificationDataclass:


### PR DESCRIPTION
Completes `work/coming/03-Smart Content notification.md`. Two things were undermining the "subtle, non-invasive" goal.

## Banners were stacking

`get_active_notifications()` returned every match and the renderer drew them all. A user on 2.11 who had not dismissed the Content note would, the day 2.12 shipped, get **two banners at once** — which reads as clutter no matter how politely each is worded.

The sources are now ranked and the first match wins:

1. **Update available** — time-sensitive and about the thing they are already running.
2. **Content** — an invitation with no deadline, so it waits its turn.
3. **Housekeeping** — never urgent.

Nothing is lost: what gets skipped surfaces once whatever outranked it is dismissed or no longer applies. This also produces a better rhythm on its own — the update notice appears *before* upgrading, and the Content note lands on the first visit *after*, when there is no update left to report and the user is already in a "what changed" frame of mind.

## The note read like an ad because it was shaped like one

The update notice is one sentence. The Content note was a five-line paragraph listing seven products. Length was the tell.

It is now the same shape as its neighbour — one concrete fact and a link:

> 🌱 **Content — where HomeTube goes next**
> It speaks MCP, so Claude, your IDE or any agent can drive your library.
> [Take a look]

`Discover Content` became `Take a look`, which asks for less.

## One angle per release, rotating

Rather than raising frequency, the note says something **different** each release, picked deterministically from the minor version:

- *It speaks MCP, so Claude, your IDE or any agent can drive your library.*
- *REST API, CLI and a typed Python SDK — scriptable from anything that speaks HTTP.*
- *Beyond video: transcripts, summaries, translations and documents, from URLs, files or plain text.*

Each is a separate hook for someone who already runs their own containers, and a returning user meets a new detail instead of a banner they have learned to ignore. This is the "start slow" the spec asks for: still one quiet line, but never the same one twice.

## Verified

- 315 passed, 6 skipped. `black --check` and `ruff check` clean.
- New tests cover the ranking (update wins, Content surfaces once it is dismissed, Content shows after upgrading, silence when all dismissed), the rotation, and guards that every angle stays under 110 characters and contains no `deprecated` / `migrate` / `replaces` wording.
- Rendered through `streamlit.testing.v1.AppTest`: exactly **one** Content banner, correct link, no exception.

One of the new tests initially passed alone and failed in the full suite — the cleanup notification inspects the real configured tmp folder, so the ranking assertions were picking up files other tests had left behind. The fixture now pins that folder too.