### PR TITLE
feat(notifications): halve the Content note and widen the rotation

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -279,14 +279,18 @@ def get_content_announcement_id(version: str | None = None) -> str:
 
 
 # One concrete capability per release rather than the same pitch every time.
-# These are written for people who already run their own containers: a specific
-# thing the engine does, in one line, with no adjectives to sell it. The angle
-# rotates with the minor version, so a returning user meets a new detail instead
-# of a banner they have already read and ignored.
+# Written for people who already run their own containers: a specific thing the
+# engine does, short enough to read without deciding to — the goal is a glance,
+# not a paragraph. No adjectives, nothing to sell; the link does the rest.
+#
+# The angle rotates with the minor version, so a returning user meets a new
+# detail instead of a banner they have learned to skip. Four of them means the
+# same line comes back only every fourth release.
 CONTENT_ANGLES = (
-    "It speaks MCP, so Claude, your IDE or any agent can drive your library.",
-    "REST API, CLI and a typed Python SDK — scriptable from anything that speaks HTTP.",
-    "Beyond video: transcripts, summaries, translations and documents, from URLs, files or plain text.",
+    "It speaks MCP — drive it from Claude or your IDE.",
+    "REST API, CLI and a Python SDK, included.",
+    "Not just video: transcripts, summaries, translations.",
+    "Send any page to it, straight from your browser.",
 )
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -324,11 +324,21 @@ class TestContentAnnouncement:
             ):
                 assert word not in lowered, f"{word!r} in {angle!r}"
 
-    def test_angles_stay_one_line(self):
-        """The note earns its subtlety by being as short as the update notice."""
+    def test_angles_stay_glanceable(self):
+        """Short enough to read without deciding to — one sentence, no list.
+
+        The cap is the whole point of the note: past roughly a line it stops
+        being a detail in passing and starts being a paragraph asking for
+        attention, which is the thing that makes a header feel like an ad.
+        """
         for angle in CONTENT_ANGLES:
-            assert len(angle) <= 110, f"{len(angle)} chars: {angle!r}"
-            assert angle.count(".") <= 2
+            assert len(angle) <= 60, f"{len(angle)} chars: {angle!r}"
+            assert angle.count(".") <= 2, f"more than one sentence: {angle!r}"
+
+    def test_enough_angles_to_stay_fresh(self):
+        """A line should not come back before the user has forgotten it."""
+        assert len(CONTENT_ANGLES) >= 4
+        assert len(set(CONTENT_ANGLES)) == len(CONTENT_ANGLES)
 
     def test_angle_rotates_with_the_release(self):
         """A returning user meets a new detail, not the banner they already read."""


### PR DESCRIPTION
Follow-up to #119 on Yann's read of the rendered banner: still too much text, and worth rotating over more angles.

## Half the length

Average angle goes from **83 characters to 47** (was 71–97, now 41–53). The point is a line you read without deciding to — past roughly that, it stops being a detail in passing and becomes a paragraph asking for attention, which is what makes a header feel like an ad.

| Before | After |
|---|---|
| It speaks MCP, so Claude, your IDE or any agent can drive your library. | It speaks MCP — drive it from Claude or your IDE. |
| REST API, CLI and a typed Python SDK — scriptable from anything that speaks HTTP. | REST API, CLI and a Python SDK, included. |
| Beyond video: transcripts, summaries, translations and documents, from URLs, files or plain text. | Not just video: transcripts, summaries, translations. |

## Four angles instead of three

Adds the browser-extension hook — *"Send any page to it, straight from your browser."* — so the same line only comes back every fourth release rather than every third. Four distinct hooks for someone who already self-hosts: agents, automation, capabilities beyond video, and the browser.

The rendered block is now three short lines and the ✕ button, which is what the whole design was aiming at:

> 🌱 **Content — where HomeTube goes next**
> Send any page to it, straight from your browser.
> [Take a look]

`Take a look` is kept over `Discover Content` — it asks for less, which is the same instinct as the shorter copy.

## Verified

- 316 passed, 6 skipped. `black --check` and `ruff check` clean.
- The length guard drops from 110 to **60 characters** and now also rejects more than one sentence, so the brevity is enforced rather than merely intended. A second test requires at least four distinct angles.
- Rendered through `AppTest`: one banner, one ✕, correct link, no exception.

While tightening the guard I had written an assertion ending in `or True`, which can never fail. Removed rather than left in place — a test that always passes is worse than no test.