### PR TITLE
chore(release): bump version to 2.12.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,5 +2,5 @@
 HomeTube - YouTube Video Downloader with Streamlit UI
 """
 
-__version__ = "2.11.0"
+__version__ = "2.12.0"
 __author__ = "Yann ORIEULT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hometube"
-version = "2.11.0"
+version = "2.12.0"
 description = "HomeTube development workspace"
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "hometube"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Release preparation for **v2.12.0**. A minor bump: user-visible behaviour changes in the notification header, no breaking change to configuration, volumes or defaults.

Updates `pyproject.toml`, `app/__init__.py` and the `hometube` entry in `uv.lock` — the three files `make version-update` touches, done by hand since `uv` is not installed on this machine.

Being a minor release, it also triggers the in-app *New version available!* notice for instances running 2.11, which is the point: those users get the update prompt first, and the Content note on their next visit once there is no update left to report.

Verified: 316 passed, 6 skipped. On this version the announcement resolves to `content_announcement_v2.12` and serves the MCP angle — *"It speaks MCP — drive it from Claude or your IDE."*