### PR TITLE
fix(logs): give the download-logs button a key that cannot repeat

### DIFF
--- a/app/logs_utils.py
+++ b/app/logs_utils.py
@@ -5,12 +5,27 @@ Provides centralized logging functionality and error message analysis
 for better user experience and debugging.
 """
 
+import itertools
+
 import streamlit as st
 
 from app.constants import AUTH_ERROR_PATTERNS
 from app.file_system_utils import is_valid_cookie_file
 
 # === LOGGING FUNCTIONS ===
+
+
+# Streamlit refuses a widget key it has already seen during the same script run.
+# The "download logs" button used to discriminate on len(ALL_LOGS), which worked
+# only while that number kept climbing — the buffer is capped at MAX_LOG_LINES,
+# so on a long fragmented download the count sticks and every later render asks
+# for the same key (issue #123). A counter that only ever goes up cannot stick.
+_download_button_renders = itertools.count()
+
+
+def next_download_button_key(run_seq: int) -> str:
+    """Return a key no earlier render of the download-logs button has used."""
+    return f"download_logs_btn_{run_seq}_{next(_download_button_renders)}"
 
 
 def safe_push_log(message: str):

--- a/app/main.py
+++ b/app/main.py
@@ -78,6 +78,7 @@ from app.logs_utils import (
     log_authentication_error_hint,
     log_format_unavailable_error_hint,
     register_main_push_log,
+    next_download_button_key,
 )
 from app.cut_utils import (
     get_keyframes,
@@ -3355,9 +3356,6 @@ ALL_LOGS: list[str] = []  # global buffer (complete log content)
 # Fragmented (HLS) downloads emit one progress line per fragment, so the buffer
 # must stay bounded or memory grows for the whole download (issue #82)
 MAX_LOG_LINES = 10000
-run_unique_key = (
-    f"download_logs_btn_{st.session_state.run_seq}"  # unique key per execution
-)
 
 
 def render_download_button():
@@ -3368,8 +3366,8 @@ def render_download_button():
             data="\n".join(ALL_LOGS),
             file_name="logs.txt",
             mime="text/plain",
-            # Unique key with log count
-            key=f"download_logs_btn_{st.session_state.run_seq}_{len(ALL_LOGS)}",
+            # Fresh key every render — see next_download_button_key (issue #123)
+            key=next_download_button_key(st.session_state.run_seq),
         )
 
 

--- a/tests/test_logs_utils.py
+++ b/tests/test_logs_utils.py
@@ -1,0 +1,41 @@
+"""Tests for logging helpers."""
+
+from app.logs_utils import next_download_button_key
+
+
+class TestDownloadButtonKey:
+    """Keys for the "download logs" button.
+
+    Reproduces issue #123: the key used to be built from len(ALL_LOGS), which
+    stops changing once the buffer hits MAX_LOG_LINES, so a second render in the
+    same script run reused a key Streamlit had already registered and raised
+    StreamlitDuplicateElementKey — killing the download in progress.
+    """
+
+    def test_consecutive_renders_get_different_keys(self):
+        keys = [next_download_button_key(2) for _ in range(5)]
+
+        assert len(set(keys)) == 5, keys
+
+    def test_key_does_not_depend_on_the_log_count(self):
+        """The saturated-buffer case: nothing about the logs feeds the key.
+
+        A capped counter is exactly what broke before, so the key must be
+        derived from something that cannot plateau.
+        """
+        before = next_download_button_key(7)
+        after = next_download_button_key(7)
+
+        assert before != after
+
+    def test_key_carries_the_run_sequence(self):
+        """Runs stay distinguishable, as they were with the old scheme."""
+        key = next_download_button_key(42)
+
+        assert key.startswith("download_logs_btn_42_")
+
+    def test_keys_stay_unique_across_runs(self):
+        first_run = [next_download_button_key(1) for _ in range(3)]
+        second_run = [next_download_button_key(2) for _ in range(3)]
+
+        assert len(set(first_run + second_run)) == 6


### PR DESCRIPTION
Fixes #123.

The "download logs" button keyed itself on the size of the log buffer:

```python
key=f"download_logs_btn_{st.session_state.run_seq}_{len(ALL_LOGS)}"
```

That only works while the number keeps climbing. #82 capped the buffer at `MAX_LOG_LINES = 10000` to stop memory growing on fragmented downloads, so on a long enough download the count plateaus, a later render asks for a key Streamlit has already registered in the same run, and:

```
streamlit.errors.StreamlitDuplicateElementKey:
There are multiple elements with the same key='download_logs_btn_2_10000'.
```

It compounds: the exception handler calls `push_log()`, which renders the same key again and raises a second identical traceback. The playlist stops with the current entry stranded in the temporary workspace.

Worth noting this is a **latent regression from #82** — the memory bound was right, but it removed the property the key silently depended on.

## The fix

`next_download_button_key()` in `app/logs_utils.py`, backed by an `itertools.count()`. It derives the key from something monotonic instead of something capped, so it cannot plateau. The 10,000-line bound is untouched.

Same approach @stanthewizzard proposed, moved into `logs_utils` rather than kept as a module global in `main.py`: `app/main.py` executes Streamlit at import time and no test can import it, so a helper there is untestable. In `logs_utils` it is a plain function with plain tests.

Also drops `run_unique_key`, a leftover that computed a key nothing ever read.

## Verified

- New `tests/test_logs_utils.py`: consecutive renders differ, the key no longer depends on the log count, the run sequence is still carried, and keys stay distinct across runs.
- Full suite: 320 passed, 6 skipped. `black --check` and `ruff check` clean.
- App re-rendered through `AppTest` after the import change: no exception, widgets intact.

Thanks @stanthewizzard — spotting that the cap and the key were coupled is the whole bug.