### PR TITLE
chore(release): bump version to 2.12.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,5 +2,5 @@
 HomeTube - YouTube Video Downloader with Streamlit UI
 """
 
-__version__ = "2.12.0"
+__version__ = "2.12.1"
 __author__ = "Yann ORIEULT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hometube"
-version = "2.12.0"
+version = "2.12.1"
 description = "HomeTube development workspace"
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 
 [[package]]
 name = "hometube"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Release preparation for **v2.12.1**. A patch: two crash fixes reported from the field, no new behaviour.

- #124 — a CIFS/SMB destination rejecting `utime()` no longer aborts a completed cross-device move, and the playlist keeps going (#122).
- #125 — the download-logs button no longer reuses a widget key once the log buffer saturates, so long fragmented downloads no longer die on `StreamlitDuplicateElementKey` (#123).

Being a patch, it is deliberately quiet: `docs/releasing.md` notes the in-app *New version available!* notice only fires for major/minor updates. Verified that the Content announcement also stays silent — `get_content_announcement_id()` returns `content_announcement_v2.12` for both 2.12.0 and 2.12.1, so nobody who dismissed it gets asked again for a bug-fix release.

Verified: 320 passed, 6 skipped.