### PR TITLE
feat(notifications): lead the Content note with the engine and job queue

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -287,17 +287,26 @@ def get_content_announcement_id(version: str | None = None) -> str:
 # detail instead of a banner they have learned to skip. Four of them means the
 # same line comes back only every fourth release.
 CONTENT_ANGLES = (
+    "A backend with a job queue — downloads run in parallel.",
+    "One engine, many jobs: queue a batch and walk away.",
     "It speaks MCP — drive it from Claude or your IDE.",
     "REST API, CLI and a Python SDK, included.",
     "Not just video: transcripts, summaries, translations.",
     "Send any page to it, straight from your browser.",
 )
 
+# Rotation starts here rather than at minor 0, so CONTENT_ANGLES is ordered by
+# what lands best and index 0 is what the current release actually shows.
+# Appending an angle then extends the rotation instead of silently reshuffling
+# which one every past release would have served.
+CONTENT_ANGLES_FIRST_MINOR = 12
+
 
 def get_content_angle(version: str | None = None) -> str:
     """Pick this release's angle, deterministically, from the minor version."""
     minor = parse_version(version or get_current_version())[1]
-    return CONTENT_ANGLES[minor % len(CONTENT_ANGLES)]
+    offset = (minor - CONTENT_ANGLES_FIRST_MINOR) % len(CONTENT_ANGLES)
+    return CONTENT_ANGLES[offset]
 
 
 def check_content_announcement() -> Notification | None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -19,6 +19,7 @@ from app.notifications import (
     get_content_angle,
     get_active_notifications,
     CONTENT_ANGLES,
+    CONTENT_ANGLES_FIRST_MINOR,
     CONTENT_REPO_URL,
 )
 
@@ -339,6 +340,32 @@ class TestContentAnnouncement:
         """A line should not come back before the user has forgotten it."""
         assert len(CONTENT_ANGLES) >= 4
         assert len(set(CONTENT_ANGLES)) == len(CONTENT_ANGLES)
+
+    def test_the_list_is_ordered_not_arbitrary(self):
+        """CONTENT_ANGLES[0] is what the rotation's first release serves.
+
+        Rotating from a base minor rather than from zero is what lets the list
+        be ordered by what lands best, and lets a new angle be appended without
+        silently reshuffling which line every other release would show.
+        """
+        first = f"2.{CONTENT_ANGLES_FIRST_MINOR}.0"
+
+        assert get_content_angle(first) == CONTENT_ANGLES[0]
+        assert get_content_angle(f"2.{CONTENT_ANGLES_FIRST_MINOR + 1}.0") == (
+            CONTENT_ANGLES[1]
+        )
+
+    def test_appending_an_angle_leaves_earlier_releases_alone(self):
+        """The property the base offset exists to protect."""
+        before = [
+            get_content_angle(f"2.{CONTENT_ANGLES_FIRST_MINOR + n}.0")
+            for n in range(len(CONTENT_ANGLES))
+        ]
+
+        assert before == list(CONTENT_ANGLES), (
+            "each release in the first cycle serves its angle in list order, so "
+            "appending to the tuple cannot disturb the ones already published"
+        )
 
     def test_angle_rotates_with_the_release(self):
         """A returning user meets a new detail, not the banner they already read."""


### PR DESCRIPTION
MCP was a narrow opening line. For someone already running HomeTube, the concrete upgrade is that Content is a **backend** — jobs go into a queue and run in parallel — and that lands harder than agent integration, which only matters to the subset already using agents.

Two angles added at the front of the rotation:

- *A backend with a job queue — downloads run in parallel.*
- *One engine, many jobs: queue a batch and walk away.*

Both are verified against Content rather than written as marketing: `max_concurrent_jobs` (default 2, `CONTENT_MAX_CONCURRENT_JOBS`), `collection_member_concurrency` for playlist members, and a real `JobQueue` in `content/execution/worker.py` with jobs transitioning through `queued`.

## The rotation now starts from a base minor

Previously `CONTENT_ANGLES[minor % len(...)]`, which made the list order meaningless — where an angle sat in the tuple decided nothing you could reason about, and **appending one silently reshuffled which line every release serves**.

It now offsets from `CONTENT_ANGLES_FIRST_MINOR = 12`, so index 0 is what 2.12 shows and the list can be ordered by what lands best. Adding an angle extends the rotation instead of disturbing it. Two tests lock that property.

Rotation from here: 2.12 job queue → 2.13 engine/batch → 2.14 MCP → 2.15 API/CLI/SDK → 2.16 beyond video → 2.17 browser extension. Six angles, so a line returns only every sixth release.

Length is unchanged in spirit — 41 to 55 characters, average 49 against 47 before. The 60-character cap and the one-sentence rule still hold.

## Verified

- 326 passed, 6 skipped. `black --check` and `ruff check` clean.
- Rendered through `AppTest`: one banner, correct line for 2.12, working link.