### PR TITLE
chore(deps): ignore websockets majors while streamlit pins them below 17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,20 @@ updates:
       timezone: "Europe/Zurich"
     open-pull-requests-limit: 5
     ignore:
-      # numpy is a transitive dep of streamlit, which still pins "numpy<3".
-      # Dependabot proposes the major bump anyway and CI stays green (nothing
-      # imports numpy directly), but the resulting environment violates
-      # streamlit's own constraint. Drop this once streamlit allows 3.x.
+      # Transitive deps of streamlit whose majors its own pins forbid:
+      # "numpy<3" and "websockets<17" as of streamlit 1.62. Dependabot proposes
+      # them anyway and CI stays green — nothing imports either directly, and
+      # CI installs from pyproject.toml rather than from these files — but the
+      # resulting requirements would contradict streamlit's constraint.
+      # Re-check both against streamlit's requires_dist when its pin moves,
+      # and drop the entry rather than carrying it out of habit.
       #
-      # pandas used to be listed here for the same reason. streamlit 1.62
-      # widened its pin to "pandas<4", so major pandas updates are allowed
-      # again and are no longer ignored.
+      # pandas and pillow were both listed here for the same reason under
+      # streamlit 1.49 ("pandas<3", "pillow<12"). 1.62 widened them to
+      # "pandas<4" and "pillow<13", so their majors flow again.
       - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "websockets"
         update-types: ["version-update:semver-major"]
     groups:
       python-minor-patch:


### PR DESCRIPTION
Dependabot opened #130 to take websockets from 16.1.1 to **17.1**. streamlit 1.62 declares:

```
websockets<17,>=12.0.0
```

so that update would leave `requirements/*.txt` contradicting the constraint of the one package that actually pulls websockets in.

Its CI passed, and that is the trap worth naming: nothing imports websockets directly, and neither CI nor the Docker image reads the compiled requirements — both install from `pyproject.toml`. A green check on these dependency PRs says the test suite still runs, not that the pin is satisfiable. That is the same shape as pandas 3.0.5 and pillow 12.3.0 before it.

Adds `websockets` beside `numpy` in the `ignore` list so the PR is not reopened weekly, and rewrites the comment to say *why* an entry is there and when to remove it — pandas and pillow were both on that list under streamlit 1.49 and came off once 1.62 widened to `pandas<4` and `pillow<13`. The list is meant to shrink as streamlit moves, not to accumulate.

#130 should be closed rather than merged.

The other four from this batch were checked the same way and merged: click 8.5.0 (streamlit allows `click<9`), plus rpds-py, pytz and tzdata, none of which carry an upper bound from jsonschema, referencing or pandas.