### PR TITLE
docs(legal): state copyright, authorship and contribution terms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,31 @@
+HomeTube — authors and contributors
+
+See NOTICE for copyright and licensing, and LICENSE for the licence text.
+
+Author and maintainer
+---------------------
+
+Yann Orieult
+
+  Commits appear in this repository under several git identities. They are all
+  the same person:
+
+    EgalitarianMonkey  <48605580+EgalitarianMonkey@users.noreply.github.com>
+    Yann ORIEULT       <48605580+EgalitarianMonkey@users.noreply.github.com>
+    Yann ORIEULT       <egalitarianmonkey@gmail.com>
+    Yann ORIEULT       <yo.managements@gmail.com>
+
+  This is written down because two different names against the same history
+  can read as two authors, which would misstate who holds copyright.
+
+Contributors
+------------
+
+Contributions below were received under the project licence; their authors
+retain copyright in them. See NOTICE for the details of each.
+
+  Devon Campbell  <devon@radworks.io>
+    Jellyfin integration — commit 1ad1d32, 2025-10-21, pull request #54.
+
+Automated dependency updates are made by dependabot[bot]. They carry no
+copyrightable authorship and no contributor is listed for them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,29 @@ Example PR checklist:
 
 ---
 
+## 📜 Licensing of contributions
+
+HomeTube is licensed under the **AGPL-3.0-or-later** — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
+
+By submitting a contribution — a pull request, a patch, or any code, documentation or other material — you agree to all of the following.
+
+- **You keep your copyright.** Nothing here assigns it or takes it away from you.
+- **You license your contribution under the project licence**, AGPL-3.0-or-later, so that it can be distributed as part of HomeTube.
+- **You grant the project's author a perpetual, worldwide, irrevocable, royalty-free right to relicense your contribution**, including under commercial or proprietary terms, as part of HomeTube or a work derived from it.
+- **You confirm you are entitled to grant this** — the work is yours, or you have permission from whoever owns it, an employer for instance.
+
+### Why the relicensing grant is asked
+
+HomeTube is one person's project, released under a copyleft licence. Without this grant, any future change to how HomeTube is offered — a commercial edition, a different licence, inclusion in a differently-licensed work — would require locating every past contributor and obtaining their individual agreement. Asking once, up front, keeps that option open rather than quietly closing it with each merge.
+
+The grant does not make your contribution any less free: it stays under the AGPL for everyone, exactly as before.
+
+### If you would rather not grant it
+
+Say so in your pull request. Your contribution can still be accepted under the AGPL alone. It simply means it could not be included in any future relicensing, and might have to be reimplemented if that ever happens — so it is better said openly at the time than discovered later.
+
+---
+
 ## 🔐 Security
 
 - Never submit API keys, cookies, or tokens.  

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,59 @@
+HomeTube — self-hosted web UI for downloading and organising videos
+Copyright (C) 2025-2026 Yann Orieult
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+Source: https://github.com/EgalitarianMonkey/hometube
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+Third-party components
+----------------------
+
+HomeTube depends on third-party software that it does not include: yt-dlp,
+ffmpeg/ffprobe, Streamlit, and its other Python dependencies. Each remains
+under its own licence, held by its own authors, and nothing here alters those
+terms. The container images built from this repository are based on an
+upstream image and bundle some of these components in binary form; consult
+each component for its licence.
+
+No additional restriction is imposed beyond the licences that apply.
+
+Third-party contributions
+-------------------------
+
+The following contributions were received from their authors under the terms of
+this project's licence. Copyright in them is held by their respective authors,
+not by the author of this project.
+
+  Devon Campbell <devon@radworks.io>
+  Jellyfin integration — commit 1ad1d32, 2025-10-21, pull request #54.
+  9 files changed, 268 insertions, 6 deletions. Introduced
+  app/integrations_utils.py, tests/test_config_jellyfin.py and
+  tests/test_jellyfin_integration.py; modified app/config.py, app/main.py,
+  .env.sample, README.md, docs/docker.md and docs/installation.md.
+
+  Received under the AGPL-3.0-or-later terms of this repository. No copyright
+  assignment and no relicensing grant were requested or given at the time.
+
+Copyright ownership
+-------------------
+
+Copyright in this project is held by Yann Orieult, sole author except for the
+third-party contributions listed above, which remain with their authors.
+
+Because those contributions were received under the AGPL alone, offering
+HomeTube as a whole under different terms would require the agreement of their
+authors, or the replacement of their work. CONTRIBUTING.md sets out the terms
+that apply to contributions from now on.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Streamlit](https://img.shields.io/badge/Streamlit-1.49+-red.svg)](https://streamlit.io)
 [![Latest Release](https://img.shields.io/github/v/release/EgalitarianMonkey/hometube)](https://github.com/EgalitarianMonkey/hometube/releases)
 [![Docker Image](https://ghcr-badge.egpl.dev/egalitarianmonkey/hometube/latest_tag?trim=major&label=Docker)](https://github.com/EgalitarianMonkey/hometube/pkgs/container/hometube)
-[![License](https://img.shields.io/badge/License-AGPL--3.0-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-AGPL--3.0--or--later-green.svg)](LICENSE)
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -707,7 +707,9 @@ Every contribution is appreciated! 🙏
 
 ## 📄 License
 
-This project is licensed under the AGPL-3.0 License - see the [LICENSE](LICENSE) file for details.
+HomeTube is free software under the **GNU Affero General Public License, version 3 or later** — see [LICENSE](LICENSE) for the full text.
+
+Copyright © 2025-2026 Yann Orieult, sole author except for third-party contributions received under the project licence. [NOTICE](NOTICE) records copyright and attribution, [AUTHORS](AUTHORS) lists everyone who has contributed, and [CONTRIBUTING.md](CONTRIBUTING.md#-licensing-of-contributions) sets out the terms that apply to new contributions.
 
 ## 🙏 Acknowledgments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ name = "hometube"
 version = "2.12.1"
 description = "HomeTube development workspace"
 requires-python = ">=3.11"
+license = "AGPL-3.0-or-later"
+license-files = ["LICENSE", "NOTICE"]
+authors = [{ name = "Yann Orieult" }]
+maintainers = [{ name = "Yann Orieult" }]
 
 dependencies = [
     "streamlit>=1.49,<1.63",


### PR DESCRIPTION
Makes ownership of HomeTube unambiguous in writing. No application code is touched.

## Added

- **`NOTICE`** — modelled on Content's, so the two projects read the same way: title, `Copyright (C) 2025-2026 Yann Orieult`, SPDX identifier, source URL, the AGPL paragraphs, third-party components, third-party contributions, and copyright ownership. The year span is the real one, first commit 2025-09-15 to today.
- **`AUTHORS`** — author, maintainer, and contributors. It records that `EgalitarianMonkey` and `Yann ORIEULT` are the same person: commits appear under **four** identity strings across three addresses, which without this note reads as several authors and misstates who holds copyright.

## Changed

- **`pyproject.toml`** — `license = "AGPL-3.0-or-later"`, `license-files`, `authors`, `maintainers`. The build backend is `setuptools>=80.8.0`, past the 77.0.0 that introduced PEP 639, so the SPDX form is used rather than the deprecated classifier. Verified by building a wheel: `Metadata-Version: 2.4`, `License-Expression: AGPL-3.0-or-later`, with `LICENSE` and `NOTICE` both embedded.
- **`README.md`** — the licence section names the holder and points at `NOTICE`, `AUTHORS` and the new contribution terms. The badge said plain `AGPL-3.0`; it now says `AGPL-3.0-or-later` like everything else.
- **`CONTRIBUTING.md`** — a licensing section. Contributors keep their copyright, license their work under the project licence, and grant a perpetual right to relicense. It explains why the grant is asked, and says plainly that a contributor may decline and still be merged under the AGPL alone.

## Policy

`AGPL-3.0-or-later`, matching Content and matching the LICENSE file's own appendix wording. Previously the repo said only "AGPL-3.0", which left the version policy unstated. `NOTICE`, `README`, the badge and `pyproject.toml` now all agree.

## Not touched

`LICENSE` keeps the verbatim AGPL text — ownership is expressed in the files above, never by editing the licence. No SPDX headers were added. 326 tests pass.