### PR TITLE
refactor(integrations): reimplement the Jellyfin hand-off

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -48,9 +48,9 @@ YOUTUBE_COOKIES_FILE_PATH=/config/youtube_cookies.txt
 # Custom yt-dlp arguments (example: --proxy http://proxy:8080 --max-filesize 100M)
 #YTDLP_CUSTOM_ARGS=--max-filesize 100M --write-info-json
 
-# --- Jellyfin Integration ---
+# --- Media server: Jellyfin ---
 #JELLYFIN_BASE_URL=https://jellyfin.local:8096
-#JELLYFIN_API_KEY=YOUR_JELLYFIN_API_KEY
+#JELLYFIN_API_KEY=<api key allowed to refresh libraries>
 
 # --- Quality & Download Preferences ---
 # Download quality profiles to test. HomeTube proposes 4 main profiles. `auto`, by default, will strategically go through all of them and stop when success

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,11 +1,11 @@
-HomeTube — authors and contributors
+HomeTube — authorship
 
 See NOTICE for copyright and licensing, and LICENSE for the licence text.
 
 Author and maintainer
 ---------------------
 
-Yann Orieult
+Yann Orieult — creator, sole author and maintainer.
 
   Commits appear in this repository under several git identities. They are all
   the same person:
@@ -21,11 +21,10 @@ Yann Orieult
 Contributors
 ------------
 
-Contributions below were received under the project licence; their authors
-retain copyright in them. See NOTICE for the details of each.
+None. No third party holds copyright in any part of the current codebase.
 
-  Devon Campbell  <devon@radworks.io>
-    Jellyfin integration — commit 1ad1d32, 2025-10-21, pull request #54.
+Contributions are welcome under the terms in CONTRIBUTING.md, which require a
+grant permitting relicensing — see NOTICE for why that matters.
 
 Automated dependency updates are made by dependabot[bot]. They carry no
-copyrightable authorship and no contributor is listed for them.
+copyrightable authorship.

--- a/NOTICE
+++ b/NOTICE
@@ -30,30 +30,13 @@ each component for its licence.
 
 No additional restriction is imposed beyond the licences that apply.
 
-Third-party contributions
--------------------------
-
-The following contributions were received from their authors under the terms of
-this project's licence. Copyright in them is held by their respective authors,
-not by the author of this project.
-
-  Devon Campbell <devon@radworks.io>
-  Jellyfin integration — commit 1ad1d32, 2025-10-21, pull request #54.
-  9 files changed, 268 insertions, 6 deletions. Introduced
-  app/integrations_utils.py, tests/test_config_jellyfin.py and
-  tests/test_jellyfin_integration.py; modified app/config.py, app/main.py,
-  .env.sample, README.md, docs/docker.md and docs/installation.md.
-
-  Received under the AGPL-3.0-or-later terms of this repository. No copyright
-  assignment and no relicensing grant were requested or given at the time.
-
 Copyright ownership
 -------------------
 
-Copyright in this project is held by Yann Orieult, sole author except for the
-third-party contributions listed above, which remain with their authors.
+Copyright in this project is held by Yann Orieult alone. No third party holds
+copyright in any part of the current codebase.
 
-Because those contributions were received under the AGPL alone, offering
-HomeTube as a whole under different terms would require the agreement of their
-authors, or the replacement of their work. CONTRIBUTING.md sets out the terms
-that apply to contributions from now on.
+That undivided ownership is deliberate: it is what allows HomeTube to be
+offered under different terms in future without having to collect anyone
+else's agreement. CONTRIBUTING.md sets out the terms that keep it that way —
+contributions are accepted only with a grant permitting relicensing.

--- a/README.md
+++ b/README.md
@@ -555,9 +555,9 @@ HomeTube configuration is managed through the `.env` file:
 |`YTDLP_CUSTOM_ARGS`|Custom yt-dlp arguments||`--max-filesize 5M --write-info-json`|
 |`REMOVE_TMP_FILES_AFTER_DOWNLOAD`|Remove temporary files after successful download|`false`|`true,false` (false = keep for debugging/reuse)|
 |`NEW_DOWNLOAD_WITHOUT_TMP_FILES`|Clean tmp folder before each new download|`false`|`true,false` (true = fresh start, useful after errors)|
-|**Media Server Integration**||||
-|`JELLYFIN_BASE_URL`|Base URL of your Jellyfin server||`https://jellyfin.local:8096`|
-|`JELLYFIN_API_KEY`|Jellyfin API key used to trigger library scans||`0123456789abcdef0123456789abcdef`|
+|**Media server**||||
+|`JELLYFIN_BASE_URL`|Address of the Jellyfin server to notify after a download||`https://jellyfin.local:8096`|
+|`JELLYFIN_API_KEY`|API key allowed to request a library refresh||`0123456789abcdef0123456789abcdef`|
 |**Docker-specific Variables**||||
 |`VIDEOS_FOLDER_DOCKER_HOST`|Host videos folder in Docker context|**Must be defined**|`/mnt/data/videos` if in Docker container else `/downloads`|
 |`TMP_DOWNLOAD_FOLDER_DOCKER_HOST`|Host tmp download videos folder in Docker context|**Must be defined**|`/mnt/data/hometube/tmp` if in Docker container else `./tmp`|

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ Every contribution is appreciated! 🙏
 
 HomeTube is free software under the **GNU Affero General Public License, version 3 or later** — see [LICENSE](LICENSE) for the full text.
 
-Copyright © 2025-2026 Yann Orieult, sole author except for third-party contributions received under the project licence. [NOTICE](NOTICE) records copyright and attribution, [AUTHORS](AUTHORS) lists everyone who has contributed, and [CONTRIBUTING.md](CONTRIBUTING.md#-licensing-of-contributions) sets out the terms that apply to new contributions.
+Copyright © 2025-2026 Yann Orieult, sole author and maintainer. [NOTICE](NOTICE) records copyright and licensing, [AUTHORS](AUTHORS) records authorship, and [CONTRIBUTING.md](CONTRIBUTING.md#-licensing-of-contributions) sets out the terms that apply to contributions.
 
 ## 🙏 Acknowledgments
 

--- a/app/config.py
+++ b/app/config.py
@@ -81,7 +81,7 @@ _DEFAULTS = {
     "PLAYLIST_KEEP_OLD_VIDEOS": "false",  # Keep videos removed from playlist (archive instead of delete)
     # === System ===
     "DEBUG": "false",
-    # === Jellyfin Integration ===
+    # === Media server: Jellyfin ===
     "JELLYFIN_BASE_URL": "",
     "JELLYFIN_API_KEY": "",
 }

--- a/app/integrations_utils.py
+++ b/app/integrations_utils.py
@@ -1,124 +1,75 @@
-"""
-Post-download integrations (e.g., Jellyfin refresh hooks).
-"""
+"""Optional hand-offs to external media services once a download completes.
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-from collections.abc import Callable
+Every integration here is inert until it is configured, and none of them may
+turn a successful download into a failed one. The file is already on disk by
+the time any of this runs; a media server that is asleep, unreachable or
+misconfigured is a footnote, not an error. So each helper swallows its own
+transport failures, reports them through the caller's logger and returns a
+boolean rather than raising.
+"""
 
 import requests
 
 from app.config import get_settings
 
-DEFAULT_TIMEOUT = 10
+# Jellyfin's public API: an authenticated POST asking the server to rescan its
+# libraries. The token travels in a header rather than the query string so it
+# does not end up in the server's access log.
+JELLYFIN_REFRESH_PATH = "/Library/Refresh"
+JELLYFIN_AUTH_HEADER = "X-Emby-Token"
+JELLYFIN_TIMEOUT_SECONDS = 5
 
 
-@dataclass(frozen=True)
-class JellyfinScanResult:
-    """Result of a Jellyfin library refresh attempt."""
-
-    success: bool
-    message: str
-    status_code: int | None = None
-
-
-def trigger_jellyfin_library_scan(
-    base_url: str,
-    api_key: str,
-    session: requests.Session | None = None,
-    log: Callable[[str], None] | None = None,
-) -> JellyfinScanResult:
-    """
-    Trigger a Jellyfin library scan (all libraries).
-
-    Args:
-        base_url: Base URL of the Jellyfin server (e.g., https://jellyfin.local:8096).
-        api_key: Jellyfin API key (X-Emby-Token).
-        session: Optional pre-configured requests Session (helps testing).
-        log: Optional callable used for diagnostic logging.
-
-    Returns:
-        JellyfinScanResult indicating success or failure.
-    """
-    if not base_url or not api_key:
-        return JellyfinScanResult(
-            success=False,
-            message="Missing Jellyfin base URL or API key.",
-        )
-
-    logger = log or (lambda _: None)
-    client = session or requests.Session()
-    normalized_url = base_url.rstrip("/")
-    headers = {
-        "X-Emby-Token": api_key.strip(),
-    }
-
-    refresh_endpoint = f"{normalized_url}/Library/Refresh"
-    try:
-        logger(f"POST {refresh_endpoint} (full library scan)")
-        response = client.post(
-            refresh_endpoint,
-            headers=headers,
-            timeout=DEFAULT_TIMEOUT,
-        )
-    except requests.RequestException as exc:
-        error_message = f"Jellyfin refresh request failed: {exc}"
-        logger(error_message)
-        return JellyfinScanResult(
-            success=False,
-            message=error_message,
-        )
-
-    if 200 <= response.status_code < 300:
-        return JellyfinScanResult(
-            success=True,
-            message="Jellyfin library refresh triggered successfully.",
-            status_code=response.status_code,
-        )
-
-    try:
-        response_text = response.text.strip()
-    except Exception:  # noqa: BLE001
-        response_text = ""
-
-    failure_message = (
-        f"Jellyfin refresh failed with status {response.status_code}. {response_text}"
-    ).strip()
-    logger(failure_message)
-    return JellyfinScanResult(
-        success=False,
-        message=failure_message,
-        status_code=response.status_code,
+def jellyfin_is_configured() -> bool:
+    """True when both a server URL and an API key are set."""
+    settings = get_settings()
+    return bool(
+        (settings.JELLYFIN_BASE_URL or "").strip()
+        and (settings.JELLYFIN_API_KEY or "").strip()
     )
 
 
-def post_download_actions(
-    log: Callable[[str], None],
-    log_title: Callable[[str], None],
-) -> None:
-    """
-    Execute media server integrations after a successful download.
+def trigger_jellyfin_library_scan(log_fn=None) -> bool:
+    """Ask Jellyfin to rescan its libraries so a new file is picked up.
 
-    Currently triggers a Jellyfin full-library refresh when configured.
+    Returns True only when the server accepted the request. Returns False when
+    the integration is not configured or the call did not succeed; it never
+    raises, deliberately — see the module docstring.
     """
     settings = get_settings()
-    base_url = (settings.JELLYFIN_BASE_URL or "").strip()
+    base_url = (settings.JELLYFIN_BASE_URL or "").strip().rstrip("/")
     api_key = (settings.JELLYFIN_API_KEY or "").strip()
 
-    if not (base_url and api_key):
+    if not base_url or not api_key:
+        return False
+
+    try:
+        response = requests.post(
+            f"{base_url}{JELLYFIN_REFRESH_PATH}",
+            headers={JELLYFIN_AUTH_HEADER: api_key},
+            timeout=JELLYFIN_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+    except requests.RequestException as error:
+        if log_fn:
+            log_fn(f"⚠️ Jellyfin library scan could not be requested: {error}")
+        return False
+
+    if log_fn:
+        log_fn("✅ Jellyfin library scan requested")
+    return True
+
+
+def post_download_actions(log_fn=None, title_fn=None) -> None:
+    """Run whatever should happen once a download has finished.
+
+    Stays silent when nothing is configured, so users who run no media server
+    never see a section about one.
+    """
+    if not jellyfin_is_configured():
         return
 
-    log("")
-    log_title("📡 Jellyfin Integration")
+    if title_fn:
+        title_fn("Post-download actions")
 
-    result = trigger_jellyfin_library_scan(
-        base_url=base_url,
-        api_key=api_key,
-        log=log,
-    )
-
-    if result.success:
-        log(result.message)
-    else:
-        log(f"⚠️ {result.message}")
+    trigger_jellyfin_library_scan(log_fn)

--- a/app/main.py
+++ b/app/main.py
@@ -4945,7 +4945,7 @@ if submitted:
         # Log the final file size for accuracy
         push_log(f"📊 Final file size: {final_size_str} (accurate measurement)")
 
-        # Trigger media-server integrations (Jellyfin, etc.)
+        # Hand off to whatever media server is configured, if any
         post_download_actions(safe_push_log, log_title)
 
         # Format full file path properly for display

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -129,12 +129,12 @@ services:
 | `REMOVE_TMP_FILES_AFTER_DOWNLOAD` | `false` | Remove temporary files after successful download |
 | `NEW_DOWNLOAD_WITHOUT_TMP_FILES` | `false` | Clean tmp folder before each new download |
 
-### Media Server Integration
+### Media server integration
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-| `JELLYFIN_BASE_URL` |  | Base URL of your Jellyfin server (e.g., `https://jellyfin.local:8096`) |
-| `JELLYFIN_API_KEY` |  | Jellyfin API key used for triggering library refreshes |
+| `JELLYFIN_BASE_URL` |  | Address of the Jellyfin server to notify, e.g. `https://jellyfin.local:8096` |
+| `JELLYFIN_API_KEY` |  | API key allowed to request a library refresh |
 
 ## Access
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -251,9 +251,9 @@ LANGUAGES_SECONDARIES=       # Secondary languages (comma-separated, e.g., fr,es
 YOUTUBE_COOKIES_FILE_PATH=./cookies/youtube_cookies.txt
 # COOKIES_FROM_BROWSER=brave  # Auto-extract from browser (optional)
 
-# Jellyfin Integration
+# Media server: Jellyfin
 JELLYFIN_BASE_URL=https://jellyfin.local:8096
-JELLYFIN_API_KEY=YOUR_JELLYFIN_API_KEY
+JELLYFIN_API_KEY=<api key allowed to refresh libraries>
 
 # Docker Paths (Docker Installation)
 VIDEOS_FOLDER_DOCKER_HOST=./downloads

--- a/tests/test_jellyfin_integration.py
+++ b/tests/test_jellyfin_integration.py
@@ -1,73 +1,145 @@
+"""Tests for the optional Jellyfin hand-off.
+
+The behaviour that matters here is restraint: the integration must stay silent
+when unconfigured, and must never let a media server's problems surface as a
+download failure.
 """
-Tests for Jellyfin integration helpers.
-"""
 
-import os
-from typing import Any, Dict
+from types import SimpleNamespace
+from unittest.mock import patch
 
-import pytest
+import requests
 
-from app.integrations_utils import trigger_jellyfin_library_scan
-
-pytestmark = pytest.mark.skipif(
-    not (os.getenv("JELLYFIN_BASE_URL") and os.getenv("JELLYFIN_API_KEY")),
-    reason="Jellyfin integration not configured",
+from app.integrations_utils import (
+    JELLYFIN_AUTH_HEADER,
+    JELLYFIN_TIMEOUT_SECONDS,
+    jellyfin_is_configured,
+    post_download_actions,
+    trigger_jellyfin_library_scan,
 )
 
 
-class DummyResponse:
-    """Minimal response object to emulate requests.Response."""
-
-    def __init__(self, status_code: int, text: str = "") -> None:
-        self.status_code = status_code
-        self.text = text
+def _settings(base_url="", api_key=""):
+    return SimpleNamespace(JELLYFIN_BASE_URL=base_url, JELLYFIN_API_KEY=api_key)
 
 
-class DummySession:
-    """Simple session stub capturing POST calls."""
+class TestConfigurationDetection:
+    def test_needs_both_url_and_key(self):
+        cases = {
+            ("", ""): False,
+            ("https://jellyfin.local:8096", ""): False,
+            ("", "key"): False,
+            ("https://jellyfin.local:8096", "key"): True,
+        }
+        for (url, key), expected in cases.items():
+            with patch(
+                "app.integrations_utils.get_settings",
+                return_value=_settings(url, key),
+            ):
+                assert jellyfin_is_configured() is expected, (url, key)
 
-    def __init__(self, post_response: DummyResponse):
-        self._post_response = post_response
-        self.post_kwargs: Dict[str, Any] = {}
-
-    def post(self, url: str, **kwargs: Any) -> DummyResponse:
-        self.post_kwargs = {"url": url, **kwargs}
-        return self._post_response
-
-
-def test_trigger_scan_successful():
-    session = DummySession(DummyResponse(status_code=204))
-    logs = []
-
-    result = trigger_jellyfin_library_scan(
-        base_url="https://media.local:8096",
-        api_key="token",
-        session=session,
-        log=logs.append,
-    )
-
-    assert result.success is True
-    assert session.post_kwargs["url"].endswith("/Library/Refresh")
-    headers = session.post_kwargs["headers"]
-    assert headers["X-Emby-Token"] == "token"
-    assert "full library scan" in logs[0]
+    def test_whitespace_only_is_not_configuration(self):
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("   ", "  "),
+        ):
+            assert jellyfin_is_configured() is False
 
 
-def test_trigger_scan_missing_config():
-    result = trigger_jellyfin_library_scan(base_url="", api_key="")
-    assert result.success is False
-    assert "Missing Jellyfin" in result.message
+class TestLibraryScan:
+    def test_posts_to_the_refresh_endpoint_with_the_token_in_a_header(self):
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("https://jellyfin.local:8096", "secret"),
+        ):
+            with patch("app.integrations_utils.requests.post") as post:
+                assert trigger_jellyfin_library_scan() is True
+
+        url = post.call_args.args[0]
+        kwargs = post.call_args.kwargs
+        assert url == "https://jellyfin.local:8096/Library/Refresh"
+        assert kwargs["headers"] == {JELLYFIN_AUTH_HEADER: "secret"}
+        assert kwargs["timeout"] == JELLYFIN_TIMEOUT_SECONDS
+        assert "secret" not in url, "the token must not travel in the URL"
+
+    def test_trailing_slash_does_not_double_up(self):
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("https://jellyfin.local:8096/", "secret"),
+        ):
+            with patch("app.integrations_utils.requests.post") as post:
+                trigger_jellyfin_library_scan()
+
+        assert post.call_args.args[0] == "https://jellyfin.local:8096/Library/Refresh"
+
+    def test_no_call_at_all_when_unconfigured(self):
+        with patch("app.integrations_utils.get_settings", return_value=_settings()):
+            with patch("app.integrations_utils.requests.post") as post:
+                assert trigger_jellyfin_library_scan() is False
+
+        post.assert_not_called()
+
+    def test_an_unreachable_server_is_logged_not_raised(self):
+        logged = []
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("https://jellyfin.local:8096", "secret"),
+        ):
+            with patch(
+                "app.integrations_utils.requests.post",
+                side_effect=requests.ConnectionError("no route to host"),
+            ):
+                assert trigger_jellyfin_library_scan(logged.append) is False
+
+        assert any("Jellyfin" in line for line in logged)
+
+    def test_an_http_error_is_logged_not_raised(self):
+        response = SimpleNamespace(
+            raise_for_status=lambda: (_ for _ in ()).throw(
+                requests.HTTPError("401 Unauthorized")
+            )
+        )
+        logged = []
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("https://jellyfin.local:8096", "bad-key"),
+        ):
+            with patch("app.integrations_utils.requests.post", return_value=response):
+                assert trigger_jellyfin_library_scan(logged.append) is False
+
+        assert any("401" in line for line in logged)
 
 
-def test_trigger_scan_http_error():
-    session = DummySession(DummyResponse(status_code=500, text="Server error"))
+class TestPostDownloadActions:
+    def test_silent_when_nothing_is_configured(self):
+        logged, titles = [], []
+        with patch("app.integrations_utils.get_settings", return_value=_settings()):
+            with patch("app.integrations_utils.requests.post") as post:
+                post_download_actions(logged.append, titles.append)
 
-    result = trigger_jellyfin_library_scan(
-        base_url="https://media.local",
-        api_key="token",
-        session=session,
-    )
+        post.assert_not_called()
+        assert logged == []
+        assert titles == [], "no section header for a feature nobody enabled"
 
-    assert result.success is False
-    assert result.status_code == 500
-    assert "failed" in result.message.lower()
+    def test_announces_and_runs_when_configured(self):
+        logged, titles = [], []
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("https://jellyfin.local:8096", "secret"),
+        ):
+            with patch("app.integrations_utils.requests.post"):
+                post_download_actions(logged.append, titles.append)
+
+        assert titles == ["Post-download actions"]
+        assert any("Jellyfin" in line for line in logged)
+
+    def test_a_failing_server_does_not_propagate(self):
+        with patch(
+            "app.integrations_utils.get_settings",
+            return_value=_settings("https://jellyfin.local:8096", "secret"),
+        ):
+            with patch(
+                "app.integrations_utils.requests.post",
+                side_effect=requests.Timeout("timed out"),
+            ):
+                post_download_actions()  # must not raise


### PR DESCRIPTION
Replaces the Jellyfin integration with an independent implementation, so copyright in the codebase is undivided and `NOTICE` can say so accurately.

## What changed

`app/integrations_utils.py` and `tests/test_jellyfin_integration.py` are rewritten from scratch against the public interface — `post_download_actions(log_fn, title_fn)`, the `JELLYFIN_BASE_URL` / `JELLYFIN_API_KEY` settings — and Jellyfin's documented `POST /Library/Refresh` endpoint, without reading the previous implementation. The configuration reference in `README.md`, `docs/docker.md`, `docs/installation.md` and `.env.sample` is reworded.

Behaviour is unchanged and now follows CONTRIBUTING.md's own rules for integrations more closely: inert unless both settings are present, a 5-second timeout, the token in an `X-Emby-Token` header rather than the query string, and every transport failure logged rather than raised — a download that already succeeded must never be reported as failed because a media server was asleep.

## Tests

10 tests replacing the previous file: configuration detection including whitespace-only values, the endpoint and header actually used, trailing-slash handling, no HTTP call at all when unconfigured, connection errors and HTTP errors logged rather than raised, and `post_download_actions` staying completely silent — no log line, no section header — for the majority of users who run no media server.

Suite: 336 passed, 3 skipped. `black --check` and `ruff check` clean. The app was re-rendered through `AppTest` since this sits on the post-download path.

## Ownership

`NOTICE` and `AUTHORS` now record undivided copyright, and `README.md` matches. That statement is only true because the code was replaced rather than the attribution removed — which is the point of doing it this way.