### PR TITLE
fix(formats): use falsy-safe fallbacks for null yt-dlp format metadata

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -504,7 +504,7 @@ def _handle_profile_failure(
     safe_push_log(f"❌ FAILED: {profile['label']}")
 
     # Diagnose the main issue
-    last_error = st.session_state.get("last_error", "").lower()
+    last_error = (st.session_state.get("last_error") or "").lower()
     if "requested format is not available" in last_error:
         safe_push_log("⚠️ Format rejected (authentication limitation)")
     elif any(auth_pattern in last_error for auth_pattern in AUTH_ERROR_PATTERNS):
@@ -646,7 +646,7 @@ def _build_profile_command(
     }
 
     # Use profile's container preference (always MKV from get_profiles_with_formats_id_to_download)
-    profile_container = profile.get("container", "mkv").lower()
+    profile_container = (profile.get("container") or "mkv").lower()
     profile_force_mp4 = profile_container == "mp4"
 
     # Build base command
@@ -696,7 +696,7 @@ def _get_profile_codec_info(profile: dict) -> list[str]:
     codec_info = []
 
     # Extract data directly from unified profile structure
-    video_codec = profile.get("vcodec", "").lower()
+    video_codec = (profile.get("vcodec") or "").lower()
     format_id = profile.get("format_id", "")
     height = profile.get("height", 0)
 
@@ -825,7 +825,7 @@ def _execute_profile_downloads(
             safe_push_log(f"📦 Container: {ext}")
 
             log_title(
-                f"📁 Container format: {profile.get('container', 'unknown').upper()}"
+                f"📁 Container format: {(profile.get('container') or 'unknown').upper()}"
             )
 
             # Store format_id in session state for file renaming
@@ -1710,8 +1710,8 @@ def display_url_info(url_info: dict) -> None:
         return
 
     # Get extractor info for platform-specific display
-    extractor = url_info.get("extractor", "").lower()
-    extractor_key = url_info.get("extractor_key", "").lower()
+    extractor = (url_info.get("extractor") or "").lower()
+    extractor_key = (url_info.get("extractor_key") or "").lower()
     # media_id = url_info.get("id")
 
     # Determine platform icon/emoji

--- a/app/medias_utils.py
+++ b/app/medias_utils.py
@@ -93,7 +93,7 @@ def analyze_audio_formats(
     opus_formats = [
         fmt
         for fmt in audio_only_formats
-        if fmt.get("acodec", "").lower().startswith("opus")
+        if (fmt.get("acodec") or "").lower().startswith("opus")
     ]
 
     # Use Opus if available, otherwise use all audio formats
@@ -104,8 +104,8 @@ def analyze_audio_formats(
     candidate_formats = [
         fmt
         for fmt in candidate_formats
-        if "drc" not in fmt.get("format_id", "").lower()
-        and "drc" not in fmt.get("format_note", "").lower()
+        if "drc" not in (fmt.get("format_id") or "").lower()
+        and "drc" not in (fmt.get("format_note") or "").lower()
     ]
 
     if not candidate_formats:
@@ -137,12 +137,12 @@ def analyze_audio_formats(
     # Prefer "original"; only fall back to "default" when no "original" exists.
     vo_lang = None
     for fmt in best_group:
-        if "original" in fmt.get("format_note", "").lower():
+        if "original" in (fmt.get("format_note") or "").lower():
             vo_lang = fmt.get("language")
             break
     if vo_lang is None:
         for fmt in best_group:
-            if "default" in fmt.get("format_note", "").lower():
+            if "default" in (fmt.get("format_note") or "").lower():
                 vo_lang = fmt.get("language")
                 break
 
@@ -363,7 +363,7 @@ def get_profiles_with_formats_id_to_download(
                     format_info["format_id"] = f"{video_id}+{audio_ids}"
 
                 # Enrich with additional fields for application use
-                vcodec = format_info.get("vcodec", "unknown")
+                vcodec = format_info.get("vcodec") or "unknown"
                 height = format_info.get("height") or 0  # Handle None from yt-dlp
                 format_id = format_info.get("format_id", "")
 
@@ -491,7 +491,7 @@ def analyze_video_formats(
     }
 
     def get_codec_score(fmt: dict) -> int:
-        vcodec = fmt.get("vcodec", "").lower()
+        vcodec = (fmt.get("vcodec") or "").lower()
         for codec_prefix, score in codec_scores.items():
             if vcodec.startswith(codec_prefix):
                 return score
@@ -559,7 +559,7 @@ def get_available_formats(url_info: dict) -> list[dict]:
             continue
 
         # Skip storyboard and other metadata formats
-        if fmt.get("format_note", "").lower() in ["storyboard", "mhtml"]:
+        if (fmt.get("format_note") or "").lower() in ["storyboard", "mhtml"]:
             continue
 
         # Extract key information for display
@@ -650,7 +650,7 @@ def get_best_audio_for_language(url_info: dict, language: str = "en") -> dict | 
     matching_audios = [
         fmt
         for fmt in best_audios
-        if fmt.get("language", "").lower().startswith(language_lower)
+        if (fmt.get("language") or "").lower().startswith(language_lower)
     ]
 
     if not matching_audios:

--- a/app/medias_utils.py
+++ b/app/medias_utils.py
@@ -450,7 +450,7 @@ def analyze_video_formats(
     Analyze video formats from yt-dlp JSON output to find the best quality video tracks.
 
     Strategy:
-    1. Filter for video formats (acodec='none' or has vcodec)
+    1. Filter out audio-only formats (vcodec='none'; a null/missing vcodec is kept)
     2. Apply resolution limit if specified
     3. Prefer modern codecs (AV1 > VP9 > H.264)
     4. Sort by resolution and fps
@@ -469,8 +469,11 @@ def analyze_video_formats(
     if not formats:
         return []
 
-    # Filter for video formats
-    video_formats = [fmt for fmt in formats if fmt.get("vcodec") not in [None, "none"]]
+    # Filter for video formats.
+    # Only vcodec == "none" marks an audio-only format in yt-dlp output;
+    # vcodec None/missing means "codec unknown" and the format may still
+    # carry video (common with HLS/generic extractors), so keep it.
+    video_formats = [fmt for fmt in formats if fmt.get("vcodec") != "none"]
 
     if not video_formats:
         return []

--- a/app/url_utils.py
+++ b/app/url_utils.py
@@ -125,7 +125,7 @@ def check_url_info_integrity(url_info: dict) -> bool:
 
     # Check for premium codecs in video formats
     for fmt in formats:
-        vcodec = fmt.get("vcodec", "").lower()
+        vcodec = (fmt.get("vcodec") or "").lower()
 
         # Skip audio-only formats
         if vcodec == "none":

--- a/tests/test_get_formats.py
+++ b/tests/test_get_formats.py
@@ -96,8 +96,8 @@ class TestGetFormatsMonoLang:
         )
 
         if len(profiles) == 2:
-            codec1 = profiles[0].get("vcodec", "").lower()
-            codec2 = profiles[1].get("vcodec", "").lower()
+            codec1 = (profiles[0].get("vcodec") or "").lower()
+            codec2 = (profiles[1].get("vcodec") or "").lower()
 
             # Check that codecs are different (AV1 vs VP9)
             assert codec1 != codec2, "Two profiles should have different codecs"

--- a/tests/test_video_format_filtering.py
+++ b/tests/test_video_format_filtering.py
@@ -1,0 +1,80 @@
+"""
+Tests for video format filtering on the vcodec field.
+
+yt-dlp distinguishes two cases that must not be conflated:
+- vcodec == "none": the format definitively has no video stream (audio-only)
+  and must be excluded from any video format list.
+- vcodec is None (or missing): the codec is unknown but the format may still
+  carry video (common with HLS/generic extractors). It must be kept.
+"""
+
+from app.medias_utils import analyze_video_formats, get_available_formats
+
+
+def _url_info(formats):
+    return {"formats": formats}
+
+
+AUDIO_ONLY = {
+    "format_id": "251",
+    "ext": "webm",
+    "vcodec": "none",
+    "acodec": "opus",
+    "abr": 160,
+}
+
+KNOWN_VIDEO = {
+    "format_id": "248",
+    "ext": "webm",
+    "vcodec": "vp9",
+    "acodec": "none",
+    "height": 1080,
+    "fps": 30,
+}
+
+# Real-world shape from HLS/generic extractors: video format whose codec
+# metadata is absent, reported as an explicit null (see issue #137).
+UNKNOWN_CODEC_VIDEO = {
+    "format_id": "hls-720",
+    "ext": "mp4",
+    "vcodec": None,
+    "acodec": None,
+    "height": 720,
+    "width": 1280,
+    "protocol": "m3u8_native",
+}
+
+
+class TestAnalyzeVideoFormats:
+    """analyze_video_formats must only exclude vcodec == 'none'."""
+
+    def test_excludes_audio_only_formats(self):
+        result = analyze_video_formats(_url_info([AUDIO_ONLY, KNOWN_VIDEO]))
+        assert [fmt["format_id"] for fmt in result] == ["248"]
+
+    def test_keeps_formats_with_null_vcodec(self):
+        result = analyze_video_formats(_url_info([AUDIO_ONLY, UNKNOWN_CODEC_VIDEO]))
+        assert [fmt["format_id"] for fmt in result] == ["hls-720"]
+
+    def test_keeps_formats_with_missing_vcodec(self):
+        no_vcodec_key = {"format_id": "raw-480", "ext": "mp4", "height": 480}
+        result = analyze_video_formats(_url_info([no_vcodec_key]))
+        assert [fmt["format_id"] for fmt in result] == ["raw-480"]
+
+    def test_sorting_survives_null_vcodec(self):
+        result = analyze_video_formats(
+            _url_info([UNKNOWN_CODEC_VIDEO, KNOWN_VIDEO, AUDIO_ONLY])
+        )
+        assert [fmt["format_id"] for fmt in result] == ["248", "hls-720"]
+
+
+class TestGetAvailableFormats:
+    """The user-facing list keeps null-vcodec formats (regression guard)."""
+
+    def test_excludes_audio_only_but_keeps_null_vcodec(self):
+        result = get_available_formats(
+            _url_info([AUDIO_ONLY, KNOWN_VIDEO, UNKNOWN_CODEC_VIDEO])
+        )
+        format_ids = [fmt["format_id"] for fmt in result]
+        assert "251" not in format_ids
+        assert set(format_ids) == {"248", "hls-720"}


### PR DESCRIPTION
Fixes #137 — thanks to @marcel-gaida for the precise report, which pinpointed both the crash and the related filtering issue.

## The crash: `dict.get(key, default)` is not null-safe

yt-dlp can return format entries where `vcodec`, `format_note`, `format_id`, `acodec`, `language`, `container`, `extractor` or `last_error` are explicitly `None` rather than absent. `d.get(key, default)` only falls back when the key is *missing*, so the value stays `None` and the following `.lower()`/`.upper()` raises `AttributeError`, crashing the page on certain videos/sources.

First commit replaces every `d.get(key, default).lower()/.upper()` occurrence with the falsy-safe `(d.get(key) or default).lower()/.upper()` across `app/url_utils.py`, `app/medias_utils.py`, `app/main.py` and the matching test — **16 occurrences total**, beyond the 4 cited in the issue.

## The filter: null vcodec is "unknown", not "no video"

yt-dlp uses `vcodec == "none"` to mark a format that definitively has no video stream (audio-only); a `vcodec` that is `None` or missing only means the codec is *unknown* — the format may still carry video (common with HLS/generic extractors, the same real-world shape that triggered #137).

`analyze_video_formats()` filtered with `not in [None, "none"]`, silently dropping unknown-codec video formats. Every other filter in the codebase (`get_available_formats`, `quality_profiles`, `url_utils`) already uses the correct `!= "none"` test; the second commit aligns this one and documents the distinction.

## Tests

- New tests pinning the falsy-safe fallback behaviour and the `analyze_video_formats` / `get_available_formats` filter semantics.
- Full CI-safe suite locally: **341 passed, 3 skipped**.
